### PR TITLE
feature: creado notebook cnn multilabel básico

### DIFF
--- a/src/cnn.ipynb
+++ b/src/cnn.ipynb
@@ -1,0 +1,566 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "968536d0",
+   "metadata": {},
+   "source": [
+    "# CNN multilabel básica con Keras\n",
+    "\n",
+    "Este notebook muestra un flujo mínimo y reproducible para entrenar una red neuronal convolucional (CNN) en un problema **multietiqueta**.\n",
+    "\n",
+    "Objetivos:\n",
+    "1. Construir etiquetas multilabel a partir de MNIST.\n",
+    "2. Entrenar una CNN con salida sigmoide y pérdida `binary_crossentropy` (salida y pérdida habitual para CNN multilabel).\n",
+    "3. Evaluar con métricas adecuadas para multilabel (exact match y F1 micro)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef8d9a9a",
+   "metadata": {},
+   "source": [
+    "## Fundamento breve\n",
+    "\n",
+    "- En clasificación **multilabel**, una imagen puede pertenecer simultáneamente a varias clases; por eso usamos una neurona de salida por etiqueta con activación **sigmoide**.\n",
+    "- La pérdida estándar es **binary cross-entropy** aplicada por etiqueta y agregada sobre el vector de salida.\n",
+    "- En CNN, las capas convolucionales aprenden filtros locales con pesos compartidos y suelen alternarse con pooling para reducir dimensionalidad."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e532be74",
+   "metadata": {},
+   "source": [
+    "# Consideraciones\n",
+    "\n",
+    "Para asegurar el correcto funcionamiento del notebook se recomienda usar un entorno virtual de conda. Para ello, siga los siguiente pasos:\n",
+    "\n",
+    "* `conda create -n <nombre_entorno> python=3.11 -y`\n",
+    "* `conda activate <nombre_entorno>`\n",
+    "\n",
+    "Una vez creado y activado el entorno virtual:\n",
+    "* ``pip install jupyter``\n",
+    "* ``pip install ipykernel``\n",
+    "* ``pip install numpy``\n",
+    "* ``pip install matplotlib``\n",
+    "* ``pip install tensorflow``\n",
+    "\n",
+    "> Nota: se puede hacer un único pip install con todos los paquetes en una sola instrucción, pero para mayor claridad se han separado en distintos installs.\n",
+    "\n",
+    "Y finalmente registramos el kernel para Jupyter:\n",
+    "* `python -m ipykernel install --user --name <nombre_entorno> --display-name <nombre_display>`\n",
+    "\n",
+    "Una vez seguidos estos pasos, todas las celdas del Notebook deberían poder ejecutarse sin problema."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c6dcb810",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TensorFlow: 2.21.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import random\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import tensorflow as tf\n",
+    "from tensorflow import keras\n",
+    "from tensorflow.keras import layers\n",
+    "\n",
+    "# Fijamos la semilla para obtener resultados reproducibles\n",
+    "SEED = 42\n",
+    "os.environ['PYTHONHASHSEED'] = str(SEED)\n",
+    "random.seed(SEED)\n",
+    "np.random.seed(SEED)\n",
+    "tf.random.set_seed(SEED)\n",
+    "\n",
+    "#He tenido algún problema con esto, era para comprobar la versión\n",
+    "print('TensorFlow:', tf.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4c75fddf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x_train: (60000, 28, 28, 1) x_test: (10000, 28, 28, 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cargamos MNIST (imágenes 28x28 en escala de grises)\n",
+    "(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()\n",
+    "\n",
+    "# Normalizamos las imágenes y añadimos un canal para que sean compatibles con las capas convolucionales\n",
+    "x_train = (x_train.astype('float32') / 255.0)[..., np.newaxis]\n",
+    "x_test = (x_test.astype('float32') / 255.0)[..., np.newaxis]\n",
+    "\n",
+    "print('x_train:', x_train.shape, 'x_test:', x_test.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b07f3b35",
+   "metadata": {},
+   "source": [
+    "## Construcción de etiquetas multilabel\n",
+    "\n",
+    "Cada muestra tendrá 13 etiquetas binarias:\n",
+    "- 10 etiquetas para el dígito (`digit_0` ... `digit_9`)\n",
+    "- `is_even`\n",
+    "- `is_prime`\n",
+    "- `is_ge_5`\n",
+    "\n",
+    "Así, una misma imagen activa varias etiquetas a la vez (por ejemplo, un 8 activa `digit_8`, `is_even` y `is_ge_5`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8ad55b43",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etiquetas: ['digit_0', 'digit_1', 'digit_2', 'digit_3', 'digit_4', 'digit_5', 'digit_6', 'digit_7', 'digit_8', 'digit_9', 'is_even', 'is_prime', 'is_ge_5']\n",
+      "y_train_ml shape: (60000, 13)\n",
+      "Etiquetas por muestra (media): 2.37785\n"
+     ]
+    }
+   ],
+   "source": [
+    "def build_multilabel_targets(y):\n",
+    "    y = y.astype(int)\n",
+    "    n = y.shape[0]\n",
+    "\n",
+    "    # 10 etiquetas one-hot del dígito\n",
+    "    digit_one_hot = keras.utils.to_categorical(y, num_classes=10)\n",
+    "\n",
+    "    # 3 etiquetas binarias adicionales\n",
+    "    is_even = (y % 2 == 0).astype('float32').reshape(n, 1)\n",
+    "    is_prime = np.isin(y, [2, 3, 5, 7]).astype('float32').reshape(n, 1)\n",
+    "    is_ge_5 = (y >= 5).astype('float32').reshape(n, 1)\n",
+    "\n",
+    "    # Se concatenan las etiquetas en un array\n",
+    "    return np.concatenate([digit_one_hot, is_even, is_prime, is_ge_5], axis=1).astype('float32')\n",
+    "\n",
+    "y_train_ml = build_multilabel_targets(y_train)\n",
+    "y_test_ml = build_multilabel_targets(y_test)\n",
+    "\n",
+    "label_names = [f'digit_{i}' for i in range(10)] + ['is_even', 'is_prime', 'is_ge_5']\n",
+    "print('Etiquetas:', label_names)\n",
+    "print('y_train_ml shape:', y_train_ml.shape)\n",
+    "print('Etiquetas por muestra (media):', y_train_ml.sum(axis=1).mean())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "76158676",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "train: (20000, 28, 28, 1) (20000, 13)\n",
+      "val: (5000, 28, 28, 1) (5000, 13)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Subconjunto para entrenamiento rápido de ejemplo\n",
+    "n_train = 20000\n",
+    "n_val = 5000\n",
+    "\n",
+    "x_train_small = x_train[:n_train]\n",
+    "y_train_small = y_train_ml[:n_train]\n",
+    "\n",
+    "x_val = x_train[n_train:n_train+n_val]\n",
+    "y_val = y_train_ml[n_train:n_train+n_val]\n",
+    "\n",
+    "print('train:', x_train_small.shape, y_train_small.shape)\n",
+    "print('val:', x_val.shape, y_val.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f14997b8",
+   "metadata": {},
+   "source": [
+    "## Modelo CNN en Keras\n",
+    "\n",
+    "Diseño mínimo:\n",
+    "- Dos bloques `Conv2D + MaxPooling2D` para extraer características espaciales. Aquí se usa ReLU para que la red aprenda patrones complejos (para las primeras capas es mejor ya que es barata de calcular y entrena más rápido).\n",
+    "- `Dense` intermedia para combinar características (útil para predecir etiquetas a partir de ciertos patrones).\n",
+    "- Capa final de 13 neuronas con `sigmoid` (una probabilidad por etiqueta)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21e7b616",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:TensorFlow GPU support is not available on native Windows for TensorFlow >= 2.11. Even if CUDA/cuDNN are installed, GPU will not be used. Please use WSL2 or the TensorFlow-DirectML plugin.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"sequential\"</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1mModel: \"sequential\"\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓\n",
+       "┃<span style=\"font-weight: bold\"> Layer (type)                    </span>┃<span style=\"font-weight: bold\"> Output Shape           </span>┃<span style=\"font-weight: bold\">       Param # </span>┃\n",
+       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩\n",
+       "│ conv2d (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Conv2D</span>)                 │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">28</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">28</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">32</span>)     │           <span style=\"color: #00af00; text-decoration-color: #00af00\">320</span> │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ max_pooling2d (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">MaxPooling2D</span>)    │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">14</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">14</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">32</span>)     │             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ conv2d_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Conv2D</span>)               │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">14</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">14</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">64</span>)     │        <span style=\"color: #00af00; text-decoration-color: #00af00\">18,496</span> │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ max_pooling2d_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">MaxPooling2D</span>)  │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">7</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">7</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">64</span>)       │             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ flatten (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Flatten</span>)               │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">3136</span>)           │             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ dense (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)                   │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)            │       <span style=\"color: #00af00; text-decoration-color: #00af00\">401,536</span> │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ dropout (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dropout</span>)               │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)            │             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ dense_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)                 │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">13</span>)             │         <span style=\"color: #00af00; text-decoration-color: #00af00\">1,677</span> │\n",
+       "└─────────────────────────────────┴────────────────────────┴───────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1mLayer (type)                   \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mOutput Shape          \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m      Param #\u001b[0m\u001b[1m \u001b[0m┃\n",
+       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩\n",
+       "│ conv2d (\u001b[38;5;33mConv2D\u001b[0m)                 │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m28\u001b[0m, \u001b[38;5;34m28\u001b[0m, \u001b[38;5;34m32\u001b[0m)     │           \u001b[38;5;34m320\u001b[0m │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ max_pooling2d (\u001b[38;5;33mMaxPooling2D\u001b[0m)    │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m14\u001b[0m, \u001b[38;5;34m14\u001b[0m, \u001b[38;5;34m32\u001b[0m)     │             \u001b[38;5;34m0\u001b[0m │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ conv2d_1 (\u001b[38;5;33mConv2D\u001b[0m)               │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m14\u001b[0m, \u001b[38;5;34m14\u001b[0m, \u001b[38;5;34m64\u001b[0m)     │        \u001b[38;5;34m18,496\u001b[0m │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ max_pooling2d_1 (\u001b[38;5;33mMaxPooling2D\u001b[0m)  │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m7\u001b[0m, \u001b[38;5;34m7\u001b[0m, \u001b[38;5;34m64\u001b[0m)       │             \u001b[38;5;34m0\u001b[0m │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ flatten (\u001b[38;5;33mFlatten\u001b[0m)               │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m3136\u001b[0m)           │             \u001b[38;5;34m0\u001b[0m │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ dense (\u001b[38;5;33mDense\u001b[0m)                   │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m128\u001b[0m)            │       \u001b[38;5;34m401,536\u001b[0m │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ dropout (\u001b[38;5;33mDropout\u001b[0m)               │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m128\u001b[0m)            │             \u001b[38;5;34m0\u001b[0m │\n",
+       "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
+       "│ dense_1 (\u001b[38;5;33mDense\u001b[0m)                 │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m13\u001b[0m)             │         \u001b[38;5;34m1,677\u001b[0m │\n",
+       "└─────────────────────────────────┴────────────────────────┴───────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">422,029</span> (1.61 MB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m422,029\u001b[0m (1.61 MB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">422,029</span> (1.61 MB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m422,029\u001b[0m (1.61 MB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> (0.00 B)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m0\u001b[0m (0.00 B)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "num_labels = y_train_ml.shape[1]\n",
+    "\n",
+    "# Modelo CNN para clasificación multilabel\n",
+    "model = keras.Sequential([\n",
+    "    layers.Input(shape=(28, 28, 1)),\n",
+    "    layers.Conv2D(32, kernel_size=3, activation='relu', padding='same'),\n",
+    "    layers.MaxPooling2D(pool_size=2),\n",
+    "    layers.Conv2D(64, kernel_size=3, activation='relu', padding='same'),\n",
+    "    layers.MaxPooling2D(pool_size=2),\n",
+    "    layers.Flatten(),\n",
+    "    layers.Dense(128, activation='relu'),\n",
+    "    layers.Dropout(0.3),\n",
+    "    layers.Dense(num_labels, activation='sigmoid')\n",
+    "])\n",
+    "\n",
+    "model.compile(\n",
+    "    optimizer=keras.optimizers.Adam(learning_rate=1e-3),\n",
+    "    loss='binary_crossentropy',\n",
+    "    metrics=[keras.metrics.BinaryAccuracy(name='bin_acc')]\n",
+    ")\n",
+    "\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60bbd418",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/5\n",
+      "\u001b[1m157/157\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m4s\u001b[0m 22ms/step - bin_acc: 0.9304 - loss: 0.1777 - val_bin_acc: 0.9844 - val_loss: 0.0451\n",
+      "Epoch 2/5\n",
+      "\u001b[1m157/157\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m3s\u001b[0m 21ms/step - bin_acc: 0.9844 - loss: 0.0456 - val_bin_acc: 0.9921 - val_loss: 0.0243\n",
+      "Epoch 3/5\n",
+      "\u001b[1m157/157\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m3s\u001b[0m 20ms/step - bin_acc: 0.9897 - loss: 0.0302 - val_bin_acc: 0.9942 - val_loss: 0.0179\n",
+      "Epoch 4/5\n",
+      "\u001b[1m157/157\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m3s\u001b[0m 21ms/step - bin_acc: 0.9922 - loss: 0.0233 - val_bin_acc: 0.9950 - val_loss: 0.0157\n",
+      "Epoch 5/5\n",
+      "\u001b[1m157/157\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m3s\u001b[0m 21ms/step - bin_acc: 0.9939 - loss: 0.0181 - val_bin_acc: 0.9951 - val_loss: 0.0141\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Entrenamiento del modelo\n",
+    "\n",
+    "history = model.fit(\n",
+    "    x_train_small, y_train_small,\n",
+    "    validation_data=(x_val, y_val),\n",
+    "    epochs=5,\n",
+    "    batch_size=128,\n",
+    "    verbose=1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "316d8ff6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAnDFJREFUeJzt3Qd4VFXaB/B/ei+QQggEkkAIvRdBpXcrNnRZQVRUBAVZUVDE9ikiRVhkRdkFsaBYgHWVXqWDFKWFGggEkhBKes98z3smM5kJk5CEJNP+v+c5zp07dybn3iFyeO973uOg0Wg0ICIiIiIiIiIiqkGONfnDiIiIiIiIiIiIBINSRERERERERERU4xiUIiIiIiIiIiKiGsegFBERERERERER1TgGpYiIiIiIiIiIqMYxKEVERERERERERDWOQSkiIiIiIiIiIqpxDEoREREREREREVGNY1CKiIiIiIiIiIhqHINSRDbIwcEB77zzjrm7QURERGSXOBYjIiofBqWIrMCXX36pBjeGLTg4GL169cLq1avN3T2qAR9++CFWrlzJa01ERGQG9joW69y5szrXzz77zNxdISIb5WzuDhBR+b333nuIiIiARqNBYmKiGiANHjwY//vf/3Dvvffqj8vKyoKzM3+9bS0o9cgjj+DBBx80d1eIiIjslj2NxU6dOoV9+/YhPDwc3377LUaPHm3uLhGRDbLu/1MS2ZlBgwahY8eO+ufPPPMM6tSpg++++85oIOTu7l7jfZPBWXZ2Njw8PGAOmZmZ8PT0NMvPtjQZGRnw8vIydzeIiIhsjj2Nxb755huVDTZr1ix1Y+zcuXMqQGVpCgsLkZuba5ZrTkS3j9P3iKyYv7+/GniUvBNXso6BbMu+06dP46mnnlLv8/Pzw8iRI1Uwx9DixYvRu3dvNQhxc3ND8+bNTaZsy6BEBl9r165VgzPpx+eff44ePXqgTZs2JvsbHR2NAQMG3PK8JA1ePsfHxwe+vr7o1KkTli5dqn+9Z8+eaNmyJfbv34/u3burYNQbb7yhXktKStIPEGVwIn1ZsmTJTT/j+++/R4cOHfQ/o1WrVpg7d67+9by8PLz77ruIiopSnxMQEIC77roL69evR3ns2bMHAwcOVNdZ+ifns2PHDqNjyvu9yDESaJLz0E0ZkOMNP+PYsWP429/+hlq1aql+ivz8fLz//vto1KiR+i7lO5PrlJOTY/K7XLduHdq2bavOV7735cuX6485e/as+jmffPLJTee6c+dO9ZoMyImIiOyJrY7FhIy9JBglP0P6ajgWKznmkWwxGYPITbHWrVsbjalETEwMHnvsMQQFBal+Sj/efPNN/etyTUwFvHTXzZA8Hzt2rMreatGihbpGa9asUa/NnDkT3bp1U+M2+Tky1vvpp59KDbrJ9EQZp0nfZUwpYyExYsQIBAYGqvFgSf3791f9J6KqwaAUkRVJSUlBcnIyrly5gqNHj6o06vT0dPz9738v1/tlMJCWloZp06apbUk5l8CLIRn0NGzYUAUv5M5YWFgYXnzxRcyfP/+mzztx4gSeeOIJ9OvXTw0+JKDx5JNP4q+//sKRI0eMjpX075MnT96yr9Kne+65B9euXcPkyZPx0Ucfqc/VDTZ0rl69qu5Wymtz5sxRNR0kVV4CVl9//TWGDRuGGTNmqEGUDHQMB0cSWJJ+ywBk+vTp6mfI+wyDRjIIkmsjn/vpp5+qgVODBg1w4MCBW17nTZs2qYFNamoq3n77bTX17saNG2qAuXfv3gp/L3I+MuC6++671ba0559/3ugzHn30UTWolZ81atQote/ZZ5/F1KlT0b59exVMkkGq/IzHH3/cZIr+0KFD1TWVY2RwLZ+pC8JFRkbizjvvVAPAkmSfBPceeOCBW14bIiIia2YPYzFdoEkCaPLZrq6ueOihh0yOAWScIGMeuTk2btw41V8ZO/3666/6Y6QvXbp0UeMjGaNIP6UcgUx5rCz5rFdeeUWNXeTzdAEt2W7Xrp2aZiljIt145rfffjN6v1xzuU4uLi7qWHku11k+V8hrMtaUgJ+hhIQEdUx5v28iKgcNEVm8xYsXa+TXtWRzc3PTfPnllzcdL6+9/fbb+ueyLfuefvppo+OGDBmiCQgIMNqXmZl50+cNGDBAExkZabSvYcOG6jPXrFljtP/GjRsad3d3zeuvv260/+WXX9Z4eXlp0tPTSz1Pea+Pj4+mS5cumqysLKPXCgsL9ds9evRQP3vBggVGx8yZM0ft/+abb/T7cnNzNV27dtV4e3trUlNT1b5x48ZpfH19Nfn5+aX2pU2bNpp77rlHU1HSz6ioKHXNDPss1zUiIkLTr1+/Sn0vcu1GjBhx08/TfcYTTzxhtP/QoUNq/7PPPmu0/9VXX1X7N23adNN3+fPPP+v3paSkaOrWratp166dft/nn3+ujjt+/LjR9Q0MDDTZNyIiIlthL2MxnbFjx2rCwsL0Y5l169apn3Xw4EH9MTKOkrGN9OP69etG7zccA3Xv3l2N786fP1/qMTKOkM8pSXfdDMlzR0dHzdGjR286vuS1k3FKy5YtNb1799bvO3XqlHq/XPuCggKTfZL99evX1wwdOtTo9dmzZ2scHBw0Z8+evelnE1HlMFOKyIrIHTK5IyVNUo7lTpRkwxhOsyrLCy+8YPRcMm/kLpBk9OgY1iHQ3Q2UDBuZviXPDUmhz5Ip4JKZJBkzMpVLO24ACgoKsGzZMnVXrKxaR3Jecvdw0qRJN9UFKJm6LZlDkvJuaNWqVQgJCVF39XTkDtjLL7+s7mJu3bpV7ZOUeZkOV9ZUPDlG7oBKBlFFHDp0SL1HptLJtZXrJ01+Xp8+ffD777+r2gcV/V5upeRnyLUQEyZMMNr/j3/8Qz2WvGMYGhqKIUOG6J/LlMbhw4fj4MGD6q6gkDu68r0Y3imVO4hyfrxjSERE9sDWx2K66f9yrGQh6cZfuumEhmMAGSPExsZi/PjxatxkSPc+ySiTsc/TTz+tMs5NHVMZcj1kWmNJhtfu+vXr6nrJNTbMdJfVjGUsJtnkjo6OJvsk+yXr/pdfflFjUx05f5keKNediKoGg1JEVkTmvfft21c1+YtSAgvyF7LMq5cCj7dScjAg09d0f2nryBQ2+XwZsMgAQ+b+6+o1mRoImSLBjLi4OGzbtk0937Bhg1qhRlKhy3LmzBn1KPWibqVevXoqndzQ+fPnVQ2okgOMZs2a6V8XkgLfpEkTNVWtfv36aqBUcnqgpHLLlDs5TupNTZw4UaWf68hUQQnWGDahC2JJLQK5dobt3//+t6rnVPI6lud7uZWS34Wcq1yHxo0bG+2XoJ18r7proSPHlRwcyrkLKWwq5H333XefUU0JGZzJdyGDVSIiIltn62MxIXWVJJgk5ypT+KRJ8EkCcBLo0t1cK8+4TQJptzqmMko7b5k2eMcdd6ibaLVr11bXTqZDGl436beMkUwFtUpeQxnvrVixQj9VUuqZlucaElH5MShFZMXkL1QZIFy+fLlcGT1OTk4m9+vuoslf0pLNI3fkZs+erQZacidQ5uyLkhk+pa3uInfspNC43EEU8ijBEBlgVZXbWVlG7vRJRpPc/br//vuxefNmFaCSQJKO1EeQ67Fo0SI1kJKAktRmkkchdxDr1q1r1AyvkdSz0t1JLdm8vb0r9L3czvW4nbuQpQ3QZIApxc3lzqFcQ8lMKxkIJCIisge2OBbTZUNJhrTc7NM1GfvEx8frM8+rUmnjFcnwMsXUeUsATsZ1EpD617/+pbLG5dpJ9npFxlQ6ErSSQumG11BuiMp1IaKqY7xMBBFZHUmxFjI97XZJwUnJ5JFAg+GdPAnaVIQMuGQAIMU7pZC4pElLYcvSBmI6skqckMKcJTN8ykOKgko2kwzYDIMksuKL7nUdGVRI1o80OV6yp2TFmrfeekv/s+UOm0wRlCbXVwJVUgBd0vRlsGdq+p/uHGT6W1UG4SoaXJJzlfOSAbIuU0zIXVLJADO8FkLugsqAzfDnSDFUYbgajqwoKHcdZcAqRUuluDrvGBIRkT2zpbGYlBv473//q6buycp7JUlJBBkDSCDOcNxW2phHFkrRHVMWyRiT8UlJJTO7y/Lzzz+rgJSUFpAyD4arGRqSfssYSYqzS2H4W92Mk1IIEnSUTHFZjEeX3UZEVYO3tomsmCxTKynWEmAxDDxUlm6gYng3SdKdS/5lXh4SqJBUdFklrryr0sgSu7KKm6xIk52dbfRaee5wyXLEMo1O7uQZDhTnzZunspOk/oCQ2g2GJIAlyxcLGQiaOkbeL8Eq3euSGaVL39c1IXfUZLAjSxKbGpxKOnxlSAq/qcFaWddCyMqEhuSuq5BBlaFLly7p09OF1Lb46quv1GBN7qzqyCo2khn1ww8/qIGuTG3UXTsiIiJ7Y2tjMRkLSGBqzJgxKihVst17770q+CPjIckgl2l0MtYoOUbR9V9uZMlNPck8l+mEpo4RMnaS8zQslSCBIMOxSXmundxcM8yukhIEEpAzJHW1ZOwnpRpKZp6VHG/KmEc+U1YWlExx1tAkqnrMlCKyIqtXr9Zn/SQlJak7NpIJI4XBJTPndklQSJdBpBvALFy4UE13k4FBRchyvDLt7ccff1SDNBm43IqcwyeffKIykTp16qTu8MndqD///FNl5CxZsqTM9z/33HMq2+mpp55Sc/4lw+enn35StRlkwCQBLyGff+3aNVUHSWpKyV04CVxJAEY3oJSU7Z49e6ogk2RM/fHHH+qzpGZEWWSQI1P8ZDpgixYtVJaV1FySdHe5yynnWJklkKUfUg9CgkpSlFwGgZKpVJo2bdqo6YhffPGFGihKQG7v3r3qGspgTO5wlqwf9cwzz6jloiXdXwaPklVlahAsdw3/+c9/qvORu69ERET2wtbHYpIFFRAQoIp5myLT46Q/Mq3woYceUvWapK8yhpIxj9y0k+sji8VIxpKQMcNdd92lfr6M1WQMI8Ei+QwppyAef/xxvP7662rRFcnGknGffLaMTwyLlJdFbrjJOEmyumUMKd+PFKaXm4qGwS55/uabb+L9999XRdDlPCSzSsZAMsaSm6M6ElSTz5NrKPW9St7UI6IqUMlV+4jIzMsQy1K/bdu21Xz22WdGS+qWtQzxlStXTH5ubGysft8vv/yiad26tfr88PBwzfTp0zWLFi266ThZtveee+4ps98ff/yxet+HH35YofOVPnTr1k3j4eGh8fX11XTu3Fnz3Xff6V/v0aOHpkWLFibfm5iYqBk5cqQmMDBQ4+rqqmnVqpU6T0M//fSTpn///prg4GB1TIMGDTTPP/+85vLly/pj/u///k/9XH9/f9WPpk2baj744AO1tHB5yJLJDz30kFrmWZaLluv12GOPaTZu3Fip7yUmJkYtqSx9kddk6eSyPkPk5eVp3n33XbVcs4uLi1raefLkyZrs7Gyj43Tf5dq1a9V3L/2V8/3xxx9LPT+5/rKc8sWLF8t1PYiIiKyZPYzFZAzl7OysefLJJ0s9JjMzU+Pp6akZMmSIft/27ds1/fr10/j4+Gi8vLxU3+fNm2f0viNHjqj3yLhKzis6Olrz1ltvGR2zbt06TcuWLdXYTF7/5ptv9NfNkDwfM2aMyf795z//0URFRenHMnJ9TX2GkGvarl07dWytWrXU+HL9+vU3HffDDz+o9z/33HNlXD0iqiwH+U9VBLeIiEqaO3euKswpd8NKrjZDlkMyyuROqqxYU5G7r5JBtnHjxmrtGxEREVUex2K3T2psSZb577//rjKriKhqsaYUEVULiXf/5z//UdPGGJCyLTKVUdLtZRofERERWSaOxaqGTFeUgu0yBZGIqh5rShFRlZLimLJijNQbOnz4sLq7RLZBVs6RWl2zZs1SNSNkZR4iIiKyLByLVY3vv/9e1aKS2leScVbRlZCJqHwYlCKiKiWry0lxSSkG+cYbb6iCmGQbpNC7rFQTHR2N7777Ti27TERERJaFY7GqISvvyerLshDMiy++WEWfSkQlsaYUERERERERERHVONaUIiIiIiIiIiKiGsegFBERERERERER1TibqSlVWFiIS5cuwcfHh0XoiIiIqEpXsEpLS0NoaCgcHW3rfh7HT0RERGTO8ZPNBKUkIBUWFmbubhAREZGNunDhAurXrw9bwvETERERmXP8ZDNBKcmQ0p2wr6+vubtDRERENiI1NVXd+NKNNWwJx09ERERkzvGTzQSlHBwc1KMEpBiUIiIiouoaa9gSjp+IiIjInOMn2yqMQEREREREREREVoFBKSIiIiIiIiIiqnEMShERERERERERUY2rVE2p+fPnY8aMGUhISECbNm0wb948dO7c2eSxR48exdSpU7F//36cP38en3zyCcaPH290TEFBAd555x1888036jNlycCnnnoKU6ZMscn6DURERFVN/i7Ny8vjha0EFxcXODk58doRERERWXpQatmyZZgwYQIWLFiALl26YM6cORgwYABOnDiB4ODgm47PzMxEZGQkHn30UbzyyismP3P69On47LPPsGTJErRo0QJ//PEHRo4cCT8/P7z88suVOzMiIiI7oNFo1A2dGzdumLsrVs3f3x8hISG8GUZERERkyUGp2bNnY9SoUSpoJCQ49dtvv2HRokWYNGnSTcd36tRJNWHqdbFz50488MADuOeee9Tz8PBwfPfdd9i7d29Fu0dERGRXdAEpuTHk6enJoEolgnpyAy0pKUk9r1u3bnV8TURERER0u0Gp3NxcNQ1v8uTJ+n2Ojo7o27cvdu3ahcrq1q0bvvjiC5w8eRJNmjTBn3/+ie3bt6sAWGlycnJU00lNTa30zyciIrLWKXu6gFRAQIC5u2O1PDw81KMEpuRaciofERERkQUGpZKTk9UAuE6dOkb75XlMTEylOyEZVBJUatq0qRoIys/44IMPMGzYsFLfM23aNLz77ruV/plERETWTldDSjKk6PborqFcUwaliIiIiOxo9b0ffvgB3377LZYuXYoDBw6o2lIzZ85Uj6WRbK2UlBR9u3DhQo32mYiIyFJwURBeQyIiIiKbz5QKDAxUdw8TExON9stzKQ5aWRMnTlTZUo8//rh63qpVK7VSn2RDjRgxwuR73NzcVKvJmhM3MvNQy8u1xn4mEREREREREZGtqlBQytXVFR06dMDGjRvx4IMPqn2FhYXq+dixYyvdCSkwKrWpDEnwSz7bEsRdzcRrP/+pglK/vXw3nBwdzN0lIiIiKiILpIwfP141IiIiMiD/pi7IBQpygPyiR3mu21aPJV/PAzSFkpkh6RnGj7K/5L6bHlH6+2/5eerNdvazUcF+akrpd0V/NoBm9wEDP7Su1fcmTJigspc6duyIzp07Y86cOcjIyNCvxjd8+HDUq1dPZTnpiqMfO3ZMvx0fH49Dhw7B29sbjRs3Vvvvu+8+VUOqQYMGaNGiBQ4ePKiKnD/99NOwBL4ezjh2KRWp2flYcTAej3Sob+4uERERWbWePXuibdu2ahxxu/bt2wcvL68q6RcREVGlyD/2VbCnKOhjuF3efeV6T15RAMnw9TICTIX5/EKpdJnJMLcKB6WGDh2KK1euYOrUqWoZahlQrlmzRl/8PC4uzijr6dKlS2jXrp3+udSKktajRw9s2bJF7Zs3bx7eeustvPjii2rlm9DQUDz//PPqZ1gCf09XvNirMT5aHYPZ607g3tZ14e7iZO5uERER2SyZNi8Lnzg733qoEhQUVCN9IiIiSwn+5JWR5XOLIE1pmUEqyGP4em7Z+/TvKdpXqF18xOI5uRY3Z7ebt9WjC+Ag/6Z3kMKVxY+m9ukfYfDcsZRjTD3Ksbj1sTb5s0u+v6I/28Gg/+X82SU/z7M2zM1BI6M+GyCr9/n5+ami576+vlX++dl5Beg9cwsupWRj0qCmeKFHoyr/GURERBWRnZ2N2NhYREREwN3d3Wou3lNPPXXTYiaLFy9WWderVq3ClClTcPjwYaxbtw5hYWEqS3v37t0qM7tZs2YqG7tv376lTt+Twu8LFy7Eb7/9hrVr16oM7lmzZuH++++v1LWs7jGGOdnyuRFRFZJ/MuamA1k3gPzsKsoCKpHxY7TvFgEma+DoUhTkkaCPW9Gj4XYp+yQgpAJDhq/rgkWGr5vaV4736AIhRBYyxqhwppS9ksyof/SPxj9+/BPzN5/G0I5hLHpOREQWR+41ZeUV1PjP9XBxKvcqgHPnzsXJkyfRsmVLvPfee2rf0aNH1aMsfCIZ1ZGRkahVq5ZaXXfw4MFqmr8scPLVV1+paf8nTpxQ0/5L8+677+Ljjz/GjBkzVEb2sGHD1CIqtWub/44gEZFZFeQDWdeBrGtA5rUyHq8bP7fUTCBH53IEbkrJBlJBHMPXdQEiE69X5D2yv0TNZCIyjUGpCniwXT38e3ssjl9OxaebT+Ote5tX5O1ERETVTgJSzaeurfErfey9AfB0Ld+wQu6ayeIpnp6e+tV7Y2Ji1KMEqfr166c/VoJIbdq00T9///33sWLFCvzyyy9lLrIi2VhPPPGE2v7www/xz3/+E3v37sXAgQMrfY5ERBaXvZSXWb6AkuFjdkrlf6YEXFzcTQRuTAVzdJk/t8gWuinLp4KZP44sq0JU8gZlRm4B0rPzkZadp2pjp+dot7X7tNtpOfloXd8PQ9qZt2Y2g1IVIKvuydS9EYv24utd5/FUt3CE1fasvm+HiIjIzshCKobS09PxzjvvqKl4ly9fRn5+PrKyslQNy7K0bt1avy1F0CVtXOpWEhFZpMICbbDIMICUefXWwabbmcrm7q+tJ+NR28RjLdP7XflvH6LqlJtfqA0eqSBSPlINAkm6wJIEk7SBpXyky3P9a9rjM3LyUVjOIk0Ptg1lUMradI8KxF2NA7H9dDJmrjuBuY8XF3EnIiIyN5lGJ1lL5vi5VaHkKnqvvvoq1q9fr6b0yaq9Hh4eeOSRR9SKvmVxcXExei5TCwtlWWwiouqWl1XGtLhSps1JrSbtuu4VJ9lC5QkoGT5KQMqJ+QlEVaWwULKTSgSP9FlJss/4uWHgKT2nOKNJglJVmVTj4+4Mbzdn+Li7wEc9apu3enRBq3p+MDf+n6iCZFAr2VL3ztuO/x66hGfvikSr+ub/IomIiHR/T5V3Gp05yfQ9WV3vVnbs2KGm4g0ZMkSfOXXu3Lka6CER2T0JZOekmM5QuimLySDYlJ9V+Uvn5gt41DIdSPIMMP2aqxeLVxPdhpz8AoPMo5LZSEWZSgbPDQNJ+iym3Hw1o7aqeLo6GQeUioJJPm4uRQEl7Wu+Ra/pgkzafdrnFan3aU6WP2q1QC3rybzLelhxMB7TVh/Ht892sYovm4iIyFLIinl79uxRASZvb+9Ss5iioqKwfPlyVdxc/q596623mPFERBUnK7tVpKi3yl66DmgKK198+6YspVKCTYavS60kIip3dpIEg4yCR/oA0s31k/RBp6KsJd3ruQVVl53kXJSdpAsQ6YNJuuBRUZBJgkYSPPJR+1yMgkxebk5wdrKfQvkMSlXShH5N8Ntfl7HzzFVsPXkFPaODq/abISIismEyLW/EiBFo3ry5qhG1ePFik8fNnj0bTz/9NLp164bAwEC8/vrraolhIrJTkoqQk3rr6XD6bKaiYFNeRuV/pqt3OafFGbwuGU+8aU1Uyq+xBjmqdpLxNDbDKW9GU+D0ASXj16VVJQkK6QJJuswjoylvuuCRPqBUHHjS7nOBm7MjE1YqyEEjfyJsgAxQZTWflJQUVcy0Jnzw2zEs3BaLpiE++O3lu9WcTSIiopqSnZ2N2NhYREREwN3dnRe+mq6lOcYYNcWWz42sQEHeLbKXTASdJMhUWMl/iDo4arORTGYwBZSevSSrvBGR9tdWspMMs40qWT8pr6DqwhCuTo4GgSRTNZRuPeVNGv89b54xBjOlbsOYXo2xbN8FxCSkYfmBi3i0Y9jtfBwRERERkXXKzQAyksueDmeUxXQNyE2r/M9z8Sx/UW/dtDk3P8DRfqbEEN1q6tuNrDwkp+cUtVwkp+XgakYOrqbn6ldyK1k/KSP31vUgy0uSCb1djTOTbpry5nZzvaSSQSb3KlpshcyDQanb4O/pirG9G+PDVTGYvf4k7msTyl8IIiIiIrKPFebO7wTObgbObAESD1fygxwAD/9bT4cr+ejiUcUnRGT98goKVUDJMNB01TDoZPB4LSNXZT1Vlquz481T2EoW5b7FlDcvV2c4craR3WNQ6jYN7xqOJTvPI/5GFhbvOIfRPRvZ/R8qIiIiIrIxshiBBJ7OSBBqExC3GyjIMT7Gyc10hpJaNa6U4JK7ZC8xy4GoNJm5+SrQdEUCSiqTSZvRpAJMBtuy/0ZmXoUvpJ+HCwK9XRHo7VbUXBHg7ab2l6yXpAs8yXM3Z/7eUtVgUOo2SargP/o3wYQf/sS/Np/G0E5hqO3lWjXfDhERERGRuaRc1AahJBvq7FYgM9n4dZ9QoFEvIFJaD8AriMW9iW5BSjqnZuVrg0wSTCqR2ZRcYn9mBafLSV0k+feoLsBkGGgy3uemjpOMJyJzYlCqCjzYtp4qeH78cio+3XQaU+9rXhUfS0RERERUc3LSgHPbi7Ohrp4yft3FCwi/C2jUWxuMCmzCIBQRgPyCQlzLlKylXFWTSQWW0nKRnFH0qDKZtNvyWNEi37KiW8mAUoBu28cNgRKEkkdvN/h7uHBKHFkVBqWqgMyDfWNwUzz5n734evc5PNUtHA0CPKvio4mIiIiIqkdBPnDpQHE21MV9xivbyWp1oe2Ls6HqdwKcOSOA7EN2XkEZmUzGtZquZ+aiomvay1Q4w0CTPshkIvgkU+YcpCo4kQ1iUKqK3B0VhLujArHtVDJmrDuBeU+0q6qPJiIiIiK6ffKv5mtni4qTbwZitwE5KcbH1ArXZkJJECribm1dKCIbmTaXlqOtz6TNZCpRk6nE1Dk5tiIkZlTbU5e95IoAr6IAk48rAr2KHlWQyQ0BXq5cIIuoCINSVej1gU2x/fR2/O/PSxh1dwRa1/evyo8nIiIiKzZ//nzMmDEDCQkJaNOmDebNm4fOnTubPDYvLw/Tpk3DkiVLEB8fj+joaEyfPh0DBw7UH5OWloa33noLK1asQFJSEtq1a4e5c+eiU6dONXhWZPEyrwGxW4uzoW7EGb8uhcYjehRnQ9WOMFdPiSpMVo+7IdPmTGQzXTXa1hYKz80vrNDnuzg53DxdrpRpdFKfSeo5EVHFMChVhVrW88OQtvWw/GA8Plx1HN+NuoNplkRERIRly5ZhwoQJWLBgAbp06YI5c+ZgwIABOHHiBIKDg2+6QlOmTME333yDhQsXomnTpli7di2GDBmCnTt3quCTePbZZ3HkyBF8/fXXCA0NVcf37dsXx44dQ7169XjV7VV+DnBhr7YmlAShLh2SHJHi1x1dgLAuQKOeQGRvILQtV78jiyKBI139JW1Nppuny+ker2XkoLCC0+a8XJ2Kin6brskUYLDt685pc0TVzUEjeYw2IDU1FX5+fkhJSYGvr6/Z+nHxeiZ6z9qq/me6+KlO6NX05oEmERFRVcjOzkZsbCwiIiLg7u5uVxc1PDwc48ePV626r2VVjDEkECUZTJ9++ql6XlhYiLCwMLz00kuYNGnSTcdLkOnNN9/EmDFj9PsefvhheHh4qOBTVlYWfHx88N///hf33HOP/pgOHTpg0KBB+L//+z+rGj/RbZChfNLx4il553cAeZnGxwQ11WZBSTZUwzsBN29ecqpRGTn5pa4uZ7Q/LQep2RWbNif8PV2MVpkLKmPFOQ9Xp2o5RyKq3BiDmVJVrH4tT1Xo/Ivfz+Kj1THo3iSIaZxERER2LDc3F/v378fkyZP1+xwdHVVW065du0y+Jycn56bgmASktm/frrbz8/NRUFBQ5jGlfa40wwEjWaG0RODslqJsqC1AeoLx615BxUGoyJ6Ab6i5eko2qrBQg5SsPJXRdEW3ulyJLCbD4FNWXkGFPl+mwamMpaLpcSrI5FOUxWSwHeSjnTbn4uRYbedKRNWLQalqMKZnYyzbdwEnEtPw84GLeKxjWHX8GCIiIrICycnJKoBUp04do/3yPCYmxuR7ZGrf7Nmz0b17dzRq1AgbN27E8uXL1ecIyZLq2rUr3n//fTRr1kx91nfffaeCXI0bNy61L1Kn6t13363iM6Rql5sJnN9ZnA2VdNT4dWd3oGG34kBUcAuJfPKLodt2LSMXxy+nqnbscipOJqbhSpo20JRfwXlz7i6O+kLfQSZWnNMHn7zd4OfholY4JyLbx6BUNfDzdMHYXo3xwarjmL3uJO5rHco0USIioiJffPEF3nnnHVy8eFFlDOk88MADCAgIUNPWpP7S7t27kZGRoYIuEkyRzCJ7IQXLR40apepJyTLgEpgaOXIkFi1apD9Gakk9/fTTqn6Uk5MT2rdvjyeeeEJlZZVGsrXk2hpmSsk0QrIwhYVAwp/aTCgJQl3YAxTkGh9Tt01xECrsDsDFvqbwUtUXDD93NaM4AHVJHtOQkJpd5vuk5pK++HeJFedkO8hgxTmp5ST/PyMiMsSgVDV5smtDfLnzHOJvZGHRjliM6VX6XUsiIqIqrS9Tsp5MTXDx1K6HXQ6PPvqoqqW0efNm9OnTR+27du0a1qxZg1WrViE9PR2DBw/GBx98ADc3N3z11Ve47777VFHwBg0awNoEBgaqoFFiYqLRfnkeEhJi8j1BQUFYuXKlqnV19epVVWNKak9FRkbqj5FA1datW1XgToJLdevWxdChQ42OKUmupzSyQLIqnm6FvLNbgaxrxq/71i8qTl40Jc8r0Fw9JSuXnpOPEwmS+ZRWFHxKxYmEtFKn2DWo7YnmdX3RrK4vmtb1QV0/d31mk5sz6zMR0e1hUKqauLs4YeKAaIxfdggLtpzBE50bqPnORERE1UoCUh+aoX7MG5cAV69yHVqrVi1VjHvp0qX6oNRPP/2kgje9evVS2VNt2rTRHy9T1FasWIFffvkFY8eOhbVxdXVVBchlCt6DDz6oL3Quz291PlIzSjKh8vLy8PPPP+Oxxx676RgvLy/Vrl+/rlbp+/jjj6vtXKgKZacAsduKp+RdO2P8uqsPEHF3cTZUQONyB36JhKxndSklG8cvaafe6bKgzl3NLHV6XXSIL5rX9VEBKAlERYf4wMfdhReUiCwrKDV//nzMmDEDCQkJatA4b948dO7c2eSxR48exdSpU1Uq+fnz5/HJJ5+YXCknPj4er7/+OlavXo3MzExVD2Hx4sXo2LEjrNX9bUKxcNtZHL2UinmbTuHt+1qYu0tEREQWYdiwYWp62r/+9S+VufPtt9/i8ccfVwEpyZSS6X2//fYbLl++rIp6y2pzcXFxsFYyZW7EiBFqXCNjpjlz5qgMJ5mSJ4YPH66CTzJNUezZs0eNjdq2base5XpIIOu1117Tf6YEoOQfndHR0Th9+jQmTpyopvvpPpMsTEEeEL+/OBvq4h+AxiAzxcEJqNehqDh5L6B+R8CJwQAqn5z8ApxKTDcKPsn0OylGbkodXzcVeNIFn+QxItCLCzQRkeUHpZYtW6YGVgsWLFDLG8ugSopxSkp9cHDwTcdLgEnSyCVV/5VXXjH5mXJn784771R3RyUoJSnrp06dUndSrZkU55s8qBn+/p89+Gb3ebUqX8OA8t1FJiIiqvQ0OslaMsfPrQCZjicBFQk8derUCdu2bVM3rsSrr76K9evXY+bMmeomlawo98gjj6hV7KyVTKu7cuWKulEnN/Uk2CTTFXXFzyXgZlhfS6btTZkyBWfPnoW3t7eazig1pPz9/fXHyBLLUiNKanPVrl0bDz/8sJry6OLCQIbFTKW9eqZohbzN2qyo3DTjY2o3Kg5CSVaUu5+5ektWRFa0Mww8yRS8M1fSTRYed3Z0QONgb6PgU7O6PqrGExGRVQalZCUYubOpuwsnwSkZUErhTal1UJIMNKUJU6+L6dOnqyKbkhmlExERAVtwV1QgujcJwu8nr2DG2hP49G/tzd0lIiKyZTK9p5zT6MxJpqU99NBDKkNKsnwk20cKdYsdO3bgqaeewpAhQ9RzyZw6d+4crJ1M1Sttut6WLVuMnvfo0QPHjh0r8/NkKp+p6XxkRhlXgdgtRdlQW4CUC8ave9QCInoUB6JqNTRXT8lKio/HJkv2U5pB8fFUJKXlmDxeVqyTgFPzun7qUQJQUXW8WfeJiGwnKCV3KGUantyV05G7erIajixBXFlSI0KyrSSbSgp2Svr6iy++qIJfpcnJyVFNRwp8WqpJA5ti26kr+PWvyxh19w20CSu+y0lERGTPU/juvfdeNdX/73//u35/VFQUli9frrKpZKWmt956S01dI7I4ednAhd3FU/Iu/yUpUsWvO7kCYV2Kg1CyYp4jC0PTzdKy8xCTYBx8OpGYhuy8QpP3HhpK8fFQXzQLKZqCF+qrCpBzdTsisumgVHJyMgoKCvSp5jryPCYmptKdkNT0zz77TE0LfOONN7Bv3z68/PLLqjCo1F8wRWouvPvuu7AG8pfEkHb1sPxAPD5cdRzfP3cH/8IgIiK717t3bzXtTEoA/O1vfzPKyn766afRrVs3Vfxcak5a8s0nsrMpeYlHi4uTn98J5GcZHxPcvLg4ecNuVpG5SDVHpi1fvJ5lVPtJti9cK/HnqIiHi5Na8c5w+l3TEB94uXG9KiKyDRbxfzO5+ymFPz/88EP1vF27djhy5IiaGlhaUEqytSSIpSODVZkCaKn+0T9aZUrtib2GzSeS0LupcWCPiIjI3ki29aVLN9e/Cg8Px6ZNm4z2jRkzxui5LUznIyuRerk4CCVT8jKSjF/3rlMchIrsCfiEmKunZGGy8wpwMjHNqPbT8YRUpGXnmzxeMp1K1n6SerROjlx1kYhsV4WCUnK30snJCYmJiUb75XlISOX/Aq5bty6aN29utK9Zs2Zq6ePSyEo90qxFPX8PjLwzHJ9vPYtpq2LQPSoIzk7FBU2JiIiIyALkZgDndhQHoq4cN37d2QMIv6t4Sl5wM+18KrJrSWnZKvBkOP3ubHKGqgtVkouTFB+X2k/awJMuCFXLy9UsfScispqglEyn69ChAzZu3IgHH3xQn+Ukz0sr3FkesvKepO4bOnnyJBo2tK3ijy/2bIxl+y7gVFI6fj5wEUM7NTB3l4iIiIjsW2EBcOkQcHYTcGYLcGEPUJhncIADENq2OBtKakQ5W8+NUapa+QWFKtikCz5pp+GlqRXxTKnl6XJT7adGQd5wdebNaSKiSk3fkylzMqVOptt17twZc+bMQUZGhn41vuHDh6tC5VLzSVccXbd6jGzHx8fj0KFDanljWeZZvPLKK6puhEzfk1Vk9u7diy+++EI1WyIrYozt1Rj/99txzF5/Eve3qQcPVxa7JCIiIqpR188VFyc/uxXIvmH8ul8DbQBKmqyW51mbX5AdSsnKQ0xRzSfdFDwpPp6bb7r4eESgl376nS77qY6vG2vJEhFVZVBq6NChuHLlCqZOnYqEhAS0bdsWa9as0Rc/j4uLUzUidKRWhNSI0pk5c6ZqstSxbvnjTp06YcWKFapO1HvvvYeIiAgV7JJVeWzNk10b4sud51SBw0U7YjGmlzYwR0RERETVJOsGEPt78ZS867HGr7v5AhHdtTWhGvUGakdySp4dKSzUFR9PwTGDKXjxN0wXH/dyleLjuql3fuoxOsQHnq4WUa6XiMiqOGhkCQgbIIXO/fz8kJKSAl9fX1iy/x6Kx7jvD8HbzRlbJ/ZEgDdTwImIqOKys7MRGxurbua4u7vzElbTtbSmMUZF2ey5FeQBF/cVZ0PF7wc0BtktDk5AWOfiKXmh7QEnBhTsQVZugcp20q98dykVMQlpSM/JL7UurDb7SbsCnrQGtT3hyOLjRERVMsbg375mcF/rUCzcdhZH4lMxb9NpvHN/C3N0g4iIbITUdyReQ7sm91iTTxYHoc5tB3LTjY8JiCouTi6Fyt1tKAhHN5H77klpOfqpd7ri47HJGTBRexyuTo6IquOtn3anqwPl5+nCq0tEVI0YlDIDubMyeVAzDPv3Hnyz+zye6haO8EAvc3SFiIismCxAIlPmZap8UFCQeu7AVcAq/A9XqXkppQnkWso1JCuRkQyc3VIciEqNN37dM0A7HU+CUPLoH2aunlI1yysoxJkr6frAk24VvKsZuSaPD/By1QadDKbgRQZ5wYUrYxMR1TgGpczkzsaB6NEkCFtPXsGMdScw/2/tzdUVIiKyUhJEkelmly9fVoEpqjxPT080aNDAqC4mWZi8LCBuV3EQKuGw8etObkCDO4qzoUJayy+JuXpL1SQlM09lPxlmQJ1OSkduwc0ZozLDLjLIW198XBuA8kWQD4uPExFZCgalzGjSoKb4/dQV/PbXZTx713W0a1DLnN0hIiIrJJk9EkzJz89HQUGBubtjlZycnODs7MwsM0sj01ITjxQXJ5eAVH628TF1WgGNirKhGnQFXD3N1VuqhuLj569l6ms/6QJQl1JK/Bko4uPmjKZFQSdd7ScpPu7uwpWuiYgsGYNSZiR/WT7cvj5+2n8R01bHYNlzd3BATEREFSZT9lxcXFQjsmop8cVBKJmal5ls/LpP3eLi5DIlzzvYXD2lKpSZm6+KjRvWfjqRkIaMXNOB9vq1PIyCTy1CfdU+Tl8mIrI+DEqZ2YR+TfC/Py9hb+w1bIpJQp9mdczdJSIiIqKakZMGnNtRFIjapC1WbsjFS1uUXDclLyhaorD8dqy4hltCarZB8EkbiIq9mqFq1Zfk6uyIpiE+quC4mnoX6qeyoXzdGYAnIrIVDEqZWai/B0beGYEFW8/go9Uxqs6UM4ssEhERkS0qyAcuHSzOhrq4FyjML37dwREIbVecDVW/M+DM4vPWKDe/UNV60tV+UoGoy6m4kZln8nip81RceFxbAyoi0IvjYiIiG8eglAUY3bMRvt8Xh1NJ6Woq3+OdG5i7S0RERERV49rZ4uLkZ38HclKMX68VXhyEiugOeLDGpjX649w1HLpwQ1uE/FKqWg0vr+Dm9CcnRwc0CvIyKD6ubRKUIiIi+8OglAXw83DBS72j8P6vxzB7/Unc3zYUnq78aoiIiMjK/XcscPBr433uftrgky4QVTvSXL2jKqLL+C/Jx91ZH3hS2U+hvmgc7M3i40REpMfIh4X4+x0NsHhHLC5ez8Ki7bEY2zvK3F0iIiIiuj11WgKOzkBYl+IglEzPc+SKaLbianoO5m08pbZ7RgehXVgtFXySaXj1/Fl8nIiIysaglIVwc3bCxAHRGPf9ISzYelZN4Qv0ZhozERERWbG2fwPaDQPcfMzdE6om/9pyRq2S17KeLxaN6ARHRxaiJyKi8nOswLFUze5rHYpW9fyQnpOvv+NEREREZLXcfRmQsmGXbmTh693n1fbEAU0ZkCIiogpjUMqCyJ2lyYObqu1v98QhNjnD3F0iIiIiIjJp7oZTapW9LhG10T0qkFeJiIgqjEEpC9OtUaCaj59fqMHMtSfM3R0iIiIiopucTkrHj/svqO3XBjaFgwOn7RERUcUxKGWBJg2Sv9iB3w5fxsG46+buDhERERGRkdnrT6BQA/RtVgcdGtbi1SEiokphUMoCNQ3xxSPt66vtaatioNFozN0lIiIiIiLl8MUUrDqcoG6iykI9RERElcWglIWa0L8J3JwdsffcNWw4nmTu7hARERERKR+vjVGPD7ath+gQrqxIRESVx6CUharr54Gn74pQ29PXxCC/oNDcXSIiIiIiO7fzTDK2nUqGs6MDXunbxNzdISIiK8eglAUb3bMRanm6FBWSvGju7hARERGRHZOSEh+v0S7E87cuDdAgwNPcXSIiIivHoJQF83V3wUu9o9T27PUnkZmbb+4uEREREZGdWn8sEYcu3ICHixPG9m5s7u4QEZENYFDKwv39joZoUNsTV9Jy8O9tsebuDhERERHZoYJCDWau02ZJjbwzHME+7ubuEhER2QAGpSycq7MjXi1a1eTzrWeQnJ5j7i4RERERkZ3576F4nExMh6+7M57v3sjc3SEiInsOSs2fPx/h4eFwd3dHly5dsHfv3lKPPXr0KB5++GF1vIODA+bMmVPmZ3/00UfquPHjx1emazbp3lZ10bq+HzJyC/DPjafM3R0iIiIisiO5+YX4ZMNJtf1Cz0bw83Qxd5eIiMheg1LLli3DhAkT8Pbbb+PAgQNo06YNBgwYgKSkJJPHZ2ZmIjIyUgWbQkJCyvzsffv24fPPP0fr1q0r2i2b5ujogEmDmqrtpXvicPZKurm7RERERNV4Uy8vLw/vvfceGjVqpI6X8daaNWuMjikoKMBbb72FiIgIeHh4qGPff/99VYyaqCp9vy8OF65lIcjHDSO7aVeHJiIiMktQavbs2Rg1ahRGjhyJ5s2bY8GCBfD09MSiRYtMHt+pUyfMmDEDjz/+ONzc3Er93PT0dAwbNgwLFy5ErVq1Ktotm9etUSB6Nw1GfqEGM9Zq5/MTERGRdajoTb0pU6aoG3Xz5s3DsWPH8MILL2DIkCE4ePCg/pjp06fjs88+w6efforjx4+r5x9//LF6D1FVkYV2/rnxtNp+uU8UPFydeHGJiMg8Qanc3Fzs378fffv2Lf4AR0f1fNeuXbfVkTFjxuCee+4x+mwy9vrApnB0AFYfScD+89d5eYiIiKxERW/qff3113jjjTcwePBglXE+evRotT1r1iz9MTt37sQDDzygxk+SgfXII4+gf//+ZWZgEVXU4h3nVE1TWXhnaMcwXkAiIjJfUCo5OVmlitepU8dovzxPSEiodCe+//57dddw2rRp5X5PTk4OUlNTjZqtiw7xwSMd6qvtj1YfZ3o+ERGRFajMTT0Z58i0PUMyRW/79u365926dcPGjRtx8qS21s+ff/6pXh80aFC1nQvZlxuZuViw9YzantCviVqAh4iIqCqZ/W+WCxcuYNy4cfj2229vGnyVRQJYfn5++hYWZh93bl7p1wTuLo7Yd+461h9LNHd3iIiIqBpu6snUPsmuOnXqFAoLC7F+/XosX74cly9f1h8zadIkVR6hadOmcHFxQbt27dRCMVIOoTT2eFOPKm/B1rNIy85H0xAf3N8mlJeSiIjMG5QKDAyEk5MTEhONgyHy/FZFzEsjdw6lnkL79u3h7Oys2tatW/HPf/5TbcsgzpTJkycjJSVF3yS4ZQ/q+nngmbu0BSY/WhOD/IJCc3eJiIiIqtjcuXMRFRWlAk6urq4YO3asmvonGVY6P/zwg7qpt3TpUpVxvmTJEsycOVM9lsZeb+pRxSWmZuPLnbFq+9X+0WrhHSIiIrMGpWRQ1KFDB5UqriN37+R5165dK9WBPn364PDhwzh06JC+dezYUd3lk20JgpkiRdN9fX2Nmr14vkcj1PJ0wdkrGVj2h30E44iIiKxVZW7qBQUFYeXKlcjIyMD58+cRExMDb29vVV9KZ+LEifpsqVatWuHJJ5/EK6+8UmY5BHu9qUcV98+Np5CdV4j2DfzRp1kwLyEREVnG9D1ZOUZWyJO7cLLSixTelAGT3L0Tw4cPVwMewzoKumCTbMfHx6vt06e1q3j4+PigZcuWRs3LywsBAQFqm27m6+6iVj8RczacQkZOPi8TERGRhbqdm3pS2qBevXrIz8/Hzz//rAqb62RmZhplTgkJfslnl8aeb+pR+Z2/moFl+y7oF9pxcGCWFBERVQ/nir5h6NChuHLlCqZOnarqILRt2xZr1qzR10mIi4szGiBdunRJ1TjQkbRyaT169MCWLVuq6jzszrAuDdVqKHHXMvHvbbEY11cbpCIiIiLLIzf1RowYobLBO3fujDlz5tx0U0+CT7ospz179qgbeTLOksd33nlHBZtee+01/Wfed999+OCDD9CgQQO0aNECBw8eVHWonn76abOdJ9mG2etPIr9Qgx5NgtAlMsDc3SEiIhtW4aCUkLoG0kwpGWiSJYo1Gk2FPp/BqluT1U9eGxiNsUsP4vPfz+BvXRogyMetQteZiIiIakZFb+plZ2djypQpOHv2rJq2N3jwYHz99dfw9/fXHzNv3jy89dZbePHFF1V9ztDQUDz//PPqZxBV1vHLqfjlz0tqe+KAaF5IIiKqVg6aikaMLJSsHiMFO6U+gr2kostX9+D8HfjzYgr+fkcD/N+DrczdJSIiIptjy2MMWz43qpxnvtyHjTFJuKd1Xcz/W3teRiIiqtYxRoVrSpHlkPn9kwY1U9vf7b2AM1fSzd0lIiIiIrJSf5y7pgJSTo4O+Ee/JubuDhER2QEGpaxc10YB6NM0GAWFGsxYc8Lc3SEiIiIiK83A/7hoLPlYx/qIDPI2d5eIiMgOMChlA14f1BSODsCaownYf/6aubtDRERERFZmy8kr2HvumqpbqlvlmYiIqLoxKGUDmtTxwaMdwtT2h6tiKlxYnoiIiIjsV6FBxv2Irg1R18/D3F0iIiI7waCUjXilXxO4uzhi//nrWHcs0dzdISIiIiIr8dvhyzh2ORXebs4Y3bOxubtDRER2hEEpGxHi545n74pU29NXxyCvoNDcXSIiIiIiCydjxtnrT6rtUXdHoraXq7m7REREdoRBKRvyfA/tQOJscgaW7btg7u4QERERkYX7af9FxCZnIMDLFc/cHWHu7hARkZ1hUMqG+Li74OXe2pTrORtOISMn39xdIiIiIiILlZ1XgDkbtFlSY3o1VtP3iIiIahKDUjbmb10aomGAJ5LTc7Bw21lzd4eIiIiILNRXu84hMTUH9fw9MOyOBubuDhER2SEGpWyMLOP72oCmavuL388iKS3b3F0iIiIiIguTmp2Hf205o7bH9Y2Cm7OTubtERER2iEEpGzS4VQjahPkjM7cAczecMnd3iIiIiMjC/Pv3s7iRmYdGQV54qF09c3eHiIjsFINSNsjBwQFvDNJmS32/7wLOXEk3d5eIiIiIyEJImYd/b49V26/2j4azE/9JQERE5sG/gWxUl8gA9G0WjIJCDT5eE2Pu7hARERGRhfh002mVUd+6vh8Gtgwxd3eIiMiOMShlw14f2BSODsDao4n449w1c3eHiIiIiMzs4vVMLN0Tp7alDqlk2BMREZkLg1I2LKqOD4Z2ClPbH646Do1GY+4uEREREZEZzdlwCrkFhejWKAB3RQXyuyAiIrNiUMrGje/bBB4uTjgQdwNrjyaYuztEREREZCanEtOw/MBFtT1xQDS/ByIiMjsGpWxcHV93PHt3hNr+eM0J5BUUmrtLRERERGQGs9adRKEG6N+8Dto1qMXvgIiIzI5BKTvwXPdIBHi54mxyhlqNj4iIiIjsy58XbmDN0QRICalXmSVFREQWgkEpO+Dj7oJxfaPU9twNJ5Gek2/uLhERERFRDfp4rXY15ofa1UeTOj689kREZBEYlLITT3RugIhALySn5+KL38+auztEREREVEN2nE7GjtNX4eLkgPFFNyqJiIgsAYNSdsLFyVFf0PLf284iKTXb3F0iIiIiomomqy9/vPaE2h7WpSHCanvymhMRkcVgUMqODGoZgrZh/sjMLcCcjafM3R0iIiIiqmZrjyaqelKerk4Y06sxrzcREVl/UGr+/PkIDw+Hu7s7unTpgr1795Z67NGjR/Hwww+r4x0cHDBnzpybjpk2bRo6deoEHx8fBAcH48EHH8SJE9o7OlR15Pq/MbiZ2l627wJOJ6Xx8hIRERHZqIJCDWau046pn74zAkE+bubuEhER0e0FpZYtW4YJEybg7bffxoEDB9CmTRsMGDAASUlJJo/PzMxEZGQkPvroI4SEhJg8ZuvWrRgzZgx2796N9evXIy8vD/3790dGRkZFu0e30DmiNvo1r6MGKdPXMPBHREREZKuWH7iI00np8PNwwajukebuDhER0e0HpWbPno1Ro0Zh5MiRaN68ORYsWABPT08sWrTI5PGSATVjxgw8/vjjcHMzfXdmzZo1eOqpp9CiRQsV5Pryyy8RFxeH/fv3V7R7VA6vD4yGowOw/lgi9p27xmtGREREZGNy8gswZ4O2XMOLPRupwBQREZFVB6Vyc3NVoKhv377FH+DoqJ7v2rWryjqVkpKiHmvXrl1ln0nFGgf7YGinBmr7w1XHVQFMIiIiIrIdS/fEIf5GFur4umFEt3Bzd4eIiOj2g1LJyckoKChAnTp1jPbL84SEBFSFwsJCjB8/HnfeeSdatmxZ6nE5OTlITU01alR+r/SNgoeLEw7G3cCaI1Xz3RERERGR+WXk5OPTTafV9st9ouDu4mTuLhEREVnH6ntSW+rIkSP4/vvvyzxOiqP7+fnpW1hYWI310RYE+7rrawtMXxODvIJCc3eJiIiIiKrAou2xuJqRi/AATzzWkWNkIiKykaBUYGAgnJyckJiYaLRfnpdWxLwixo4di19//RWbN29G/fr1yzx28uTJapqfrl24cOG2f769ea57JAK9XXHuaia+2xtn7u4QERER0W26npGLL34/q7Zf6dcELk4Wdw+aiIhIr0J/S7m6uqJDhw7YuHGj0XQ7ed61a1dUltQ0koDUihUrsGnTJkRERNzyPVI03dfX16hRxXi7OWNcnyi1PXfDKaTn5PMSEhEREVmxz7aeQVpOPprV9cV9rUPN3R0iIqIyVfjWyYQJE7Bw4UIsWbIEx48fx+jRo5GRkaFW4xPDhw9XWUyGxdEPHTqkmmzHx8er7dOntfPcdVP2vvnmGyxduhQ+Pj6qPpW0rKysinaPKujxzg0QEeilUry/2HqG14+IiIjISiWkZGPJznNq+7UB0XCU5ZaJiIhsKSg1dOhQzJw5E1OnTkXbtm1VgGnNmjX64udxcXG4fPmy/vhLly6hXbt2qsl+ea9sP/vss/pjPvvsMzUFr2fPnqhbt66+LVu2rKrOk0ohKd2vD4xW2wu3xSIxNZvXioiIiMgKzd14Cjn5hegUXgs9o4PM3R0iIqJbqtQkc5lqd/78ebUC3p49e9ClSxf9a1u2bMGXX36pfx4eHq6m55VscpyOqdelPfXUU5XpHlXQgBYhaN/AH1l5BZiz4SSvHxERUTWYP3++Ghe5u7ursdPevXtLPTYvLw/vvfceGjVqpI5v06aNugloSD7LwcHhpiYZ6GR/YpMz8MMf2hqrrw1sqv4sEBERWTpWPiQ1aJk8uJm6Esv2XcDppDReFSIioiok2d9SAuHtt9/GgQMHVJBpwIABSEpKMnn8lClT8Pnnn2PevHk4duwYXnjhBQwZMgQHDx7UH7Nv3z6Vha5r69evV/sfffRRfnd2aPb6kygo1KBXdBA6hdc2d3eIiIjKhUEpUmTw0r95HRRqgI9Wn+BVISIiqkKzZ8/GqFGjVA3O5s2bY8GCBfD09MSiRYtMHv/111/jjTfewODBgxEZGalqeMr2rFmz9McEBQWp1Y91TVYwlsyqHj168LuzM0cvpeB/f15S268O0JZlICIisgYMSpGepHo7OTpgw/FE7Dl7lVeGiIioCshCL/v370ffvn2LB2COjur5rl27TL5HSiTItD1DHh4e2L59e6k/QxaNefrppzltyw7NWKu9oXh/m1C0CPUzd3eIiIjKjUEp0msc7I2hncLU9rTVMaquFxEREd2e5ORkFBQU6BeF0ZHnstqwKTK1T7KrTp06hcLCQjU1b/ny5UaLyRhauXIlbty4cct6nBLsSk1NNWpk3fbGXsOWE1fg7OiACf2amLs7REREFcKgFBkZ3zcKnq5OOHThBlYfMT1QJiIiouo1d+5cREVFoWnTpnB1dVWLzMjUP8mwMuU///kPBg0ahNDQ0DI/d9q0afDz89O3sDDtzSiyTnID8eM1MWr7sU5hCA/0MneXiIiIKoRBKTIS7OOOUXdHqm0Z5OTmF/IKERER3YbAwEA4OTkhMTHRaL88l1pQpki9KMl+ysjIUCsex8TEwNvbW9WXKkle37BhA5599tlb9mXy5MlISUnRtwsXtKu1kXXafCIJf5y/DjdnR7zcO8rc3SEiIqowBqXoJqO6RyLQ2w3nrmbiu71xvEJERES3QTKdOnTogI0bN+r3yZQ8ed61a9cy3yt1perVq4f8/Hz8/PPPeOCBB246ZvHixQgODsY999xzy764ubnB19fXqJF1KiyULCltLamnuoUjxM+4BhkREZE1YFCKbuLt5oxxfbV32+ZuPIW07DxeJSIiotswYcIELFy4EEuWLMHx48fVanqSBSVT8sTw4cNVFpPOnj17VA2ps2fPYtu2bRg4cKAKZL322mtGnyv7JCg1YsQIODs78zuyI//76xJiEtLg4+aMF3o0Mnd3iIiIKoWjFzLp8U5hWLw9FmeTM/DF72fxj/5cXpiIiKiyhg4diitXrmDq1KmquHnbtm2xZs0affHzuLg4o3pR2dnZmDJligpKybS9wYMH4+uvv4a/v7/R58q0PXmvrLpH9iOvoBCz159U28/3iEQtL1dzd4mIiKhSHDQ2ssSarB4jBTulPgJT0avGmiMJeOGb/XB3ccTWib1Qx5dp4UREZH9seYxhy+dmy77ZfR5TVh5BoLerGqN5ufE+MxERWecYg9P3qFQDWtRBh4a1kJ1XiE+K7sYRERERkflk5RbgnxtPqe2xvRozIEVERFaNQSkqlYODA94Y3FRt//DHBZxKTOPVIiIiIjKjJbvOISktB/X8PfBElwb8LoiIyKoxKEVl6tCwtsqYKtQA09fE8GoRERERmUlKVh4+23JGbb/SrwncnJ34XRARkVVjUIpu6bWBTeHk6IANx5Ow++xVXjEiIiIiM/ji9zMqMBUV7I0h7erxOyAiIqvHoBTdUqMgbzzROUxtT1t1HDZSG5+IiIjIaiSlZWPR9nNq+9UB0eqGIRERkbVjUIrKZVyfJvB0dcKfF1Pw2+HLvGpERERENWj+ptPIyitA2zB/9G9eh9eeiIhsAoNSVC5BPm54rnuk2p6x9gRy8wt55YiIiIhqwIVrmVi6N05tvzYgWi1GQ0REZAsYlKJyG3V3JAK93XD+aiaW7jnPK0dERERUAz7ZcBJ5BRrc1TgQ3RoH8poTEZHNYFCKys3LzRmv9ItS2//cdBqp2Xm8ekRERETV6ERCGlYcjFfbEwdE81oTEZFNYVCKKmRoxzBEBnnhWkYuPt+qXZKYiIiIiKrHzHUnIGvMDGoZgjZh/rzMRERkUxiUogpxdnLE6wObqu3/bI9FQko2ryARERFRNTgQdx3rjyVCFtr7R/8mvMZERGRzGJSiCpMVXzo2rIXsvEJ8sv4kryARERFRFdNoNJix5oTafrh9fTQO9uE1JiIim8OgFFWYrPgyeXAztf3j/guq1gERERERVZ3tp5Ox6+xVuDo5Ynw/ZkkREZFtqlRQav78+QgPD4e7uzu6dOmCvXv3lnrs0aNH8fDDD6vjJZgxZ86c2/5MMr8ODWthYIsQFGqA6WtizN0dIiIiIpvKkvq4KEtq2B0NUM/fw9xdIiIisoyg1LJlyzBhwgS8/fbbOHDgANq0aYMBAwYgKSnJ5PGZmZmIjIzERx99hJCQkCr5TLIMrw2MhpOjAzbFJGHXmavm7g4RERGRTVh9JAGH41Pg6eqEMb0am7s7RERElhOUmj17NkaNGoWRI0eiefPmWLBgATw9PbFo0SKTx3fq1AkzZszA448/Djc3tyr5TLIMkUHe+FvnBmp72urjKJS0KSIiIiKqtPyCQrXinnj27kgEepsePxMREdldUCo3Nxf79+9H3759iz/A0VE937VrV6U6UB2fSTXn5T5R8HJ1wl8XU/Db4cu89ERERES3YfmBeJy9koFani4YdXcEryUREdm0CgWlkpOTUVBQgDp16hjtl+cJCQmV6kBlPzMnJwepqalGjWpekI8bnuveSG3PWHsCufmF/BqIiIiIKiE7rwBzNmhXNn6xZ2P4uLvwOhIRkU2z2tX3pk2bBj8/P30LCwszd5fs1rN3R6jgVNy1THy757y5u0NERERklb7dE4dLKdkI8XXHk10bmrs7RERElhWUCgwMhJOTExITE432y/PSiphX12dOnjwZKSkp+nbhwoVK/Xy6fV5uznilr3ap4n9uPIXU7DxeViIiIqIKSM/Jx/zNp9X2uL5RcHdx4vUjIiKbV6GglKurKzp06ICNGzfq9xUWFqrnXbt2rVQHKvuZUjTd19fXqJH5PNaxPhoFeeF6Zh4WbDnDr4KIiIioAv697SyuZeQiMtALj3aoz2tHRER2ocLT9yZMmICFCxdiyZIlOH78OEaPHo2MjAy1cp4YPny4ymIyLGR+6NAh1WQ7Pj5ebZ8+fbrcn0mWz9nJEa8PbKq2/7M9FpdTsszdJSIiIiKrIMGof2+LVdsT+jdR4yoiIiJ74FzRNwwdOhRXrlzB1KlTVSHytm3bYs2aNfpC5XFxcWr1PJ1Lly6hXbt2+uczZ85UrUePHtiyZUu5PpOsQ7/mddApvBb2nbuOT9afxMePtDF3l4iIiIgs3r82n1bT91qE+mJwy7rm7g4REVGNcdBoNBrYAFl9TwqeS30pTuUznwNx1/HQv3bC0QFYNe5uNA3htEoiIrJutjzGsOVzsxaXbmSh58wtagXjL0d2Qs/oYHN3iYiIqMbGGMwNpirVvkEtDG4VgkINMH11DK8uERERURlkkRgJSHWOqI0eTYJ4rYiIyK4wKEVVbuKApnB2dMDmE1ew83QyrzARERGRCWeupOOHP7QrSL8+MBoODg68TkREZFcYlKIqFxHohb91aaC2p62OQaGkTRERERGRkdnrTqrs8r7NgtGhYW1eHSIisjsMSlG1eLlPFLxcnXA4PgW/Hr7Mq0xERERk4Eh8Cn47fBmSHPXqgGheGyIisksMSlG1CPR2wws9GqntGWtjkJNfwCtNREREVOTjtSfU4wNtQrkwDBER2S0GpajaPHN3BIJ93HDhWha+2R3HK01EREQEYPfZq/j95BVVg/OVfk14TYiIyG4xKEXVxtPVWT/QmrfpFFKy8ni1iYiIyK5pNBp8vEa7QvHjncPQMMDL3F0iIiIyGwalqFo92qE+Ggd740ZmHhZsPcOrTURERHZtw/EkHIi7AXcXR7zcO8rc3SEiIjIrBqWoWjk7OWLSwKZqe9H2WFy6kcUrTkREdmn+/PkIDw+Hu7s7unTpgr1795Z6bF5eHt577z00atRIHd+mTRusWbPmpuPi4+Px97//HQEBAfDw8ECrVq3wxx9/VPOZUGUVFGows6iW1Mg7IxDs686LSUREdo1BKap2fZoFo3NEbeTkF2L2+pO84kREZHeWLVuGCRMm4O2338aBAwdUkGnAgAFISkoyefyUKVPw+eefY968eTh27BheeOEFDBkyBAcPHtQfc/36ddx5551wcXHB6tWr1XGzZs1CrVq1avDMqCJ++TMeJxLT4OvujBe6axeEISIismcOGpnYbgNSU1Ph5+eHlJQU+Pr6mrs7VMLBuOsY8q+datnjVS/fjWZ1+R0REZH9jDEkM6pTp0749NNP1fPCwkKEhYXhpZdewqRJk246PjQ0FG+++SbGjBmj3/fwww+rbKhvvvlGPZf37dixA9u2bTPruVH55OYXos/sLWoBmIkDojGmV2NeOiIislnlHWMwU4pqRLsGtXBPq7qQEOj0ouKeRERE9iA3Nxf79+9H37599fscHR3V8127dpl8T05Ojpq2Z0gCUtu3b9c//+WXX9CxY0c8+uijCA4ORrt27bBw4cIy+yKfK4NEw0Y1Y9m+OBWQCvR2w8g7w3nZiYiIGJSimiR3BWXp4y0nrmDH6WRefCIisgvJyckoKChAnTp1jPbL84SEBJPvkal9s2fPxqlTp1RW1fr167F8+XJcvnxZf8zZs2fx2WefISoqCmvXrsXo0aPx8ssvY8mSJaX2Zdq0aequpa5JthZVv8zcfMzdeFptv9ynsVqhmIiIiJgpRTUoPNALf7+jodqetvo4CgttYuYoERFRlZs7d64KNjVt2hSurq4YO3YsRo4cqTKsdCRY1b59e3z44YcqS+q5557DqFGjsGDBglI/d/LkySqNXtcuXLjAb68GLN5xDsnpOQir7YHHOzXgNSciIirC6XtUo17q3Rjebs44Ep+K//11iVefiIhsXmBgIJycnJCYmGi0X56HhISYfE9QUBBWrlyJjIwMnD9/HjExMfD29kZkZKT+mLp166J58+ZG72vWrBni4uJK7Yubm5uq62DYqHqlZObh861n1PaEfk3g6szhNxERkQ7/VqQaFeDthhd6aAfUM9aeQE5+Ab8BIiKyaZLp1KFDB2zcuNEoy0med+3atcz3Sl2pevXqIT8/Hz///DMeeOAB/Wuy8t6JEyeMjj958iQaNtRmJZNlWPD7GaRm5yO6jg/ub1PP3N0hIiKyKAxKUY175q5I1PF1w8XrWfh613l+A0REZPMmTJigipBLvafjx4+r+k+SBSVT8sTw4cPV1DqdPXv2qBpSUjdKVtcbOHCgCmS99tpr+mNeeeUV7N69W03fO336NJYuXYovvvjCaMU+Mq+k1Gws3hGrtl8dEA0nRwd+JURERAYYlKIa5+HqpNLXxbxNp1VaOxERkS0bOnQoZs6cialTp6Jt27Y4dOgQ1qxZoy9+LlPuDIuYZ2dnY8qUKWp63pAhQ1S2lKy85+/vrz+mU6dOWLFiBb777ju0bNkS77//PubMmYNhw4aZ5RzpZjLOyc4rRPsG/ujbLJiXiIiIqAQHjUZjE9WmZUljWUVGinayPoLlyy8oxKC523AqKR3P94jE5EHNzN0lIiIiuxtj2PK5mdv5qxnoM2sr8gs1+G7UHejaKMDcXSIiIrK4MQYzpcgsnJ0cMWlQU/2KNPE3svhNEBERkc34ZP1JFZDq3iSIASkiIqJSMChFZtO7aTC6RNRGbn4hZq87yW+CiIiIbEJMQir++6d2leHXBkSbuztEREQWi0EpMhsHBwdMHqydtrf84EUcu5TKb4OIiIis3sy1JyAFMu5pVRct6/mZuztEREQWi0EpMqu2Yf64p3VdNXD7aE0Mvw0iIiKyavvPX8OG40lqpb0J/bULuxAREVEVBqXmz5+P8PBwuLu7o0uXLti7d2+Zx//4449o2rSpOr5Vq1ZYtWqV0evp6ekYO3Ys6tevDw8PD7XSzIIFCyrTNbJCktbu4uSA309ewfZTyebuDhEREVGlyPpB09ecUNuPtK+PRkHevJJERERVGZRatmwZJkyYgLfffhsHDhxAmzZtMGDAACQlJZk8fufOnXjiiSfwzDPP4ODBg3jwwQdVO3LkiP4Y+TxZFvmbb77B8ePHMX78eBWk+uWXXyraPbJCDQO8MKxLQ7U9bfVxFBbaxIKQREREZGe2nryCvbHX4OrsiHF9o8zdHSIiItsLSs2ePRujRo3CyJEj9RlNnp6eWLRokcnj586di4EDB2LixIlo1qwZ3n//fbRv3x6ffvqpUeBqxIgR6Nmzp8rAeu6551Sw61YZWGQ7XurdGD5uzjh6KRW/FBUGJSIiIrIWclNtxlptltTwOxoi1N/D3F0iIiKyraBUbm4u9u/fj759+xZ/gKOjer5r1y6T75H9hscLyawyPL5bt24qKyo+Pl6lPW/evBknT55E//79S+1LTk4OUlNTjRpZrwBvN7zQs5HalgFddl6BubtEREREVG6rjlxWN9e83ZzxYq/GvHJERERVHZRKTk5GQUEB6tSpY7RfnickJJh8j+y/1fHz5s1TWVdSU8rV1VVlVkndqu7du5fal2nTpsHPz0/fwsLCKnIqZIGevjMCdXzdEH8jC9/sPm/u7hARERGVS35BIWavO6m2n707ArW9XHnliIiIrGX1PQlK7d69W2VLSSbWrFmzMGbMGGzYsKHU90yePBkpKSn6duHChRrtM1U9D1cn/KNftNqet+k0UjLzeJmJiIjI4v20/yLOJmeoYNSzd0eauztERERWw7kiBwcGBsLJyQmJiYlG++V5SEiIyffI/rKOz8rKwhtvvIEVK1bgnnvuUftat26NQ4cOYebMmTdN/dNxc3NTjWzLwx3q49/bz+JkYjr+teU0Jg9uZu4uEREREZVKSg7M2XBKbb/Ys5GavkdERETVkCklU+s6dOiAjRs36vcVFhaq5127djX5HtlveLxYv369/vi8vDzVpDaVIQl+yWeTfXFydMCkQU3V9uKd59RUPiIiIiJL9fWu80hIzUaonzv+fod2NWEiIiKqpul7EyZMwMKFC7FkyRIcP34co0ePRkZGhlqNTwwfPlxNrdMZN24c1qxZo6bkxcTE4J133sEff/yBsWPHqtd9fX3Ro0cPtTrfli1bEBsbiy+//BJfffUVhgwZUtHukQ3oFR2MOyJrIze/ELPWaVexISIiIrI0adl5KrNbjO/bBO4uTubuEhERkW0HpYYOHaqm1U2dOhVt27ZV0+wk6KQrZh4XF4fLly8bray3dOlSfPHFF2jTpg1++uknrFy5Ei1bttQf8/3336NTp04YNmyYKnj+0Ucf4YMPPsALL7xQVedJVsTBwQGTB2mn7a04GI+jl1LM3SUiIiKimyzcFovrmXloFOSFh9rX4xUiIiKqIAeNRqOBDUhNTVWr8EnRc8m+Iuv30ncH8b8/L+HuqEB8/UwXc3eHiIjslC2PMWz53Krb1fQcdP94MzJyC/CvYe0xuFVdc3eJiIjI6sYYFrH6HpEpE/tHw8XJAdtOJWPbqSu8SERERGQx5m8+owJSrer5YVBL0wv+EBERUdkYlCKL1SDAU18wdNqqGBQW2kRSHxEREVm5i9cz8c3u82p74oBoVXqAiIiIKo5BKbJoL/WOgo+bM45dTsV//4w3d3eIiIiIMHfDKeQWFKJrZIAqM0BERESVw6AUWbTaXq4Y3auR2p659iSy8wrM3SUiIiKyY6eT0vDzgYtqe+JAZkkRERHdDgalyOI9fWcEQnzdEX8jC1/tOmfu7hAREZEdm7XuJKSiQL/mddC+QS1zd4eIiMiqMShFFs/dxQkT+jdR259uOo0bmbnm7hIRERHZoT8v3MDqIwmQElKv9o82d3eIiIisHoNSZBUebl8f0XV8kJqdj39tOWPu7hAREZEdmrH2hHoc0rYeokN8zN0dIiIiq8egFFkFJ0cHTBrcVG1/ueMcLlzLNHeXiIiIyI7sPJ2M7aeT4eLkgFf6aTO4iYiI6PYwKEVWo2eTILXKjax2M3v9SXN3h4iIiOyERqPB9KIsqb91boCw2p7m7hIREZFNYFCKrIaDgwMmF2VLrTwUjyPxKebuEhEREdmBdccSVT0pDxcnjO0dZe7uEBER2QwGpciqtK7vj/vbhEKjAaaviTF3d4iIiMjGFRRqMLMoS+rpu8IR5ONm7i4RERHZDAalyOpMHBCt6jlsO5WM309eMXd3iIiIyIatPBiPU0np8PNwwXPdG5m7O0RERDaFQSmyOlLH4ck7wtX2tNUx6g4mERERUVXLyS/Q17F8oUcjFZgiIiKiqsOgFFmll3o3ho+7M45fTlV3MImIiIiq2nd74hB/IwvBPm54qpv2hhgRERFVHQalyCrV8nLFiz0bq+1Z604gO6/A3F0iIiIiG5KRk49PN59W2y/3iYKHq5O5u0RERGRzGJQiqzXyznDU9XPHpZRsLNl5ztzdISIiIhuyeEcsktNz0TDAE0M7hZm7O0RERDaJQSmyWu4uTpjQr4naljuZ1zNyzd0lIiIisgE3MnPx+e9n1baMNVycOGQmIiKqDvwblqzaQ+3ro2mID9Ky8zG/KMWeiIjIEs2fPx/h4eFwd3dHly5dsHfv3lKPzcvLw3vvvYdGjRqp49u0aYM1a9YYHfPOO+/AwcHBqDVt2rQGzsT2fbb1jBpbyBjjvtah5u4OERGRzWJQiqyak6MDJg3SDsC/2nUeF65lmrtLREREN1m2bBkmTJiAt99+GwcOHFBBpgEDBiApKcnk1ZoyZQo+//xzzJs3D8eOHcMLL7yAIUOG4ODBg0bHtWjRApcvX9a37du38+rfpoSUbHy5Q1sWYOKAaDg6OvCaEhERVRMGpcjq9WgShDsbByC3oFAVPSciIrI0s2fPxqhRozBy5Eg0b94cCxYsgKenJxYtWmTy+K+//hpvvPEGBg8ejMjISIwePVptz5o1y+g4Z2dnhISE6FtgYGANnZHt+uemU8jJL0THhrXQu2mwubtDRERk0xiUIqsn0xUmDWymtlceuoQj8Snm7hIREZFebm4u9u/fj759++r3OTo6que7du0yeaVycnLUtD1DHh4eN2VCnTp1CqGhoSpwNWzYMMTFxZV55eVzU1NTjRoVO5ecgR/2XVDbrw1sqsYYREREVH0YlCKb0Kq+Hx5oq635MG31cWg0GnN3iYiISElOTkZBQQHq1KljdEXkeUJCgsmrJFP7JLtKgk6FhYVYv349li9frqbo6Uhdqi+//FLVmvrss88QGxuLu+++G2lpaaVe+WnTpsHPz0/fwsK4qpyh2etPIr9Qg57RQegcUZt/gomIiKoZg1JkM17tHw1XJ0fsOH0Vv59KNnd3iIiIKm3u3LmIiopShctdXV0xduxYNfVPMqx0Bg0ahEcffRStW7dWQaxVq1bhxo0b+OGHH0r93MmTJyMlJUXfLlzQZgURcPRSCn7585J+TEFEREQWGpSqyOox4scff1SDKjm+VatWatBU0vHjx3H//feru3ZeXl7o1KnTLVPQiQyF1fbE8K4N1fa0VcdRUMhsKSIiMj+p8+Tk5ITExESj/fJc6kCZEhQUhJUrVyIjIwPnz59HTEwMvL291TS90vj7+6NJkyY4fbr01Wjd3Nzg6+tr1Ehr5lptXcp7W9dFy3p+vCxERESWGJSq6OoxO3fuxBNPPIFnnnlGrRjz4IMPqnbkyBH9MWfOnMFdd92lAldbtmzBX3/9hbfeeuumWgpEtzKmV2P4uDsjJiENKw7G84IREZHZSaZThw4dsHHjRv0+mZInz7t27Vrme2UsVK9ePeTn5+Pnn3/GAw88UOqx6enpakxVt27dKu2/Pdh37ho2n7iiVvX9B7OkiIiIaoyDpoLFdyQzSrKYPv30U/2gSuoRvPTSS5g0adJNxw8dOlTd5fv111/1++644w60bdtWrTwjHn/8cbi4uKiVZipLCnVKlpWkovOun31bsPUMPlodg7p+7tj8ak+4uziZu0tERGTFqmKMITf1RowYgc8//xydO3fGnDlz1DQ7yYCS2lLDhw9XwSep+ST27NmD+Ph4NV6Sx3feeUfVjJIbgpIRJV599VXcd999aNiwIS5duqRuGB46dAjHjh1TmVY1dW7WTobCj32+C/vOXccTnRtg2kOtzN0lIiIiq1feMYZjda8eI/sNjxeSWaU7XoJav/32m0o3l/3BwcEq8CUp62Xh6jFUmqe6hSPUzx2XU7Lx5c5zvFBERGR2cpNu5syZmDp1qgo0SfBICpTrip9LyQLDIubZ2dmYMmUKmjdvjiFDhqiAlay8pwtIiYsXL6ps9OjoaDz22GMICAjA7t27yx2QIq0tJ66ogJSbsyPG9YniZSEiIqpBzlW1eozc6TNFVpUpa7UZmfYn6eYfffQR/u///g/Tp09Xg7SHHnoImzdvRo8ePUx+rtxJfPfddyvSfbITkhklqff/+PFPzN98GkM7hqGWl6u5u0VERHZOipVLM0XKFxiS8Y9kPJXl+++/r9L+2aPCQg0+LqolNaJbOEL8WDqCiIjIrlbfk0wpITUSXnnlFXX3UKYB3nvvvfrpfaZw9Rgqy4Pt6qFpiA/SsvPx6ebSC74SERGR/fr18GUcv5wKHzdnjO7RyNzdISIisjuO1b16jOwv63j5TGdnZ5WebqhZs2Zlrr7H1WOoLFKodPLgZmr7q13ncOFaJi8YERER6eUVFGLWOm2W1KjukcyqJiIisvSgVGVWj5H9hseL9evX64+Xz5TC6SdOaAcFOidPnlSFO4kqq3tUIO5qHIi8Ag1mFg06iYiIiMQPf1zA+auZCPByxTN3RfCiEBERWcP0vQkTJmDhwoVYsmQJjh8/jtGjR6vV9UaOHKlel9VjZGqdzrhx41SNqFmzZqm6U7J6zB9//GFUU2HixIlqVRr53NOnT6uV/f73v//hxRdfrKrzJDvk4OCASYOaqu3/HrqEwxdTzN0lIiIisgDZeQX458ZTants78bwcqtQmVUiIiIyV1CqoqvHdOvWDUuXLsUXX3yBNm3a4KefflIr67Vs2VJ/jKwqI/WjPv74Y7Rq1Qr//ve/8fPPP+Ouu+6qqvMkO9Wynh+GtKuntj9cdVwt+0xERET2bcnOc0hMzUE9fw/8rUsDc3eHiIjIbjlobORf6ampqfDz80NKSgp8fX3N3R2yIFJPqs+srcgtKMTikZ3QKzrY3F0iIiIrYstjDFs+t9KkZOWh+8eb1eOMR1rj0Y5h5u4SERGRzSnvGMPsq+8RVbew2p4Y0U1bn2z66hgUFNpEHJaIiIgqYeHvZ1VAqnGwNx5qX5/XkIiIyIwYlCK7MKZXY/i6OyMmIQ3LD1w0d3eIiIjIDK6k5WDRjli1/Wr/Jmq1XiIiIjIfBqXILvh7uqpCpmLWupOqwCkRERHZl/mbTyMztwBt6vthQIsQc3eHiIjI7jEoRXZjeNdwVdA0ITVbf5eUiIiI7KfG5Ld7zqvt1wY2Vav0EhERkXkxKEV2w93FCf/o30Rtf7b5DK5l5Jq7S0RERFRD5mw4hbwCDe5sHIA7GwfyuhMREVkABqXIrjzYth6a1fVFWk4+Pt102tzdISIiohpwMjENKw5qa0pOHNCU15yIiMhCMChFdsXR0QFvDNYORr/efQ5xVzPN3SUiIiKqZjPXnoAsvjugRR20DfPn9SYiIrIQDEqR3bk7Kgh3RwWqFP4Z606YuztERERUjQ7GXce6Y4mQhfZe7R/Na01ERGRBGJQiu/S6KnAK/O/PS/jr4g1zd4eIiIiqyYy12htQD7Wvj6g6PrzOREREFoRBKbJLLev5YUjbemr7w1XHodFozN0lIiIiqmLbTyVj55mrcHVyxPi+Uby+REREFoZBKbJbE/o3gauzI3afvYYtJ66YuztERERUheSG04y1MWr7b10aoH4tT15fIiIiC8OgFNktGZw+1S1cbX+0OgYFUgGViIiIbMLaown482IKPF2dMLZ3Y3N3h4iIiExgUIrs2piejeHn4YITiWn4+YB2qWgiIiKybvkFhfpaUs/cFYFAbzdzd4mIiIhMYFCK7JqfpwvG9tLePZ297iSycgvM3SUiIiK6TcsPxuPMlQz4e7pgVPdIXk8iIiILxaAU2b0nuzZEPX8PJKRmY9GOWLu/HkRERNYsJ78AczecUtsv9mwEX3cXc3eJiIiISsGgFNk9dxcnvDqgiboOC7acwbWMXLu/JkRERNbq291xiL+RhRBfdwzvqq0dSURERJaJQSkiAA+0qYfmdX2RlpOP6atjcJ2BKSIiIquTnpOP+ZtPq+2X+0SpG09ERERkuZzN3QGr8esrQO1IIKo/ENgEcHAwd4+oCjk6OuCNwc3w9//swbI/LqgWHuCJtmH+aBPmrx6bh/rCzZmDWyIiIkv1n22xuJqRq/4Of7RjfXN3h4iIiG6BQanySEsE/lik3V43BfBvADTupw1QRdwNuHqV62PIst0VFYhJg5pi2b4LiE3OwLmrmaqtPHRJve7i5KCyqXRBKmnhAV4qoEVERETmJdPvF247q7Yn9I+GixMnBBAREVk6B41Go4ENSE1NhZ+fH1JSUuDr61u1H551Hfjze+DUOuDcDqAgp/g1Jzcg/C5tgCqqHxDQqGp/NpnFjcxc/HkxBX9euIFDRc1UrSlfd2ejIJVsc9lpIiLbUq1jDDOzpXP74LdjWLgtVt1A+vWlu3jTiIiIyArGGAxKVVRuBhC7TRugOrUeSIkzfl03xU8CVA3vAlzcK/P9kYWR2O3F61k4eOGGPlB1JD4FOfmFNx1bv5aHPkglrUWoHzxcOe2PiMha2VLgxlbP7XJKFnrM2ILc/EIsHtkJvaKDzd0lIiIiu5bKoFQNkCSzKyeA0+u1QarzO4HC/OLXnT2AiO7aAJUEqmo1rIleUQ3JKyjEiYQ0o0DVmSvp6o+FISdHBzQN8dFnUrUL80ejIG/ewSUishK2Erix5XObvPwvfLf3AjqH18ay5++AA2t/EhERmRWDUuaQnQrEbi3Ookq7bPx6YHRRgKof0KAb4Oxqlm5S9UnNzsPhiyn6KX/SrqQZTPcs4u3mjNb1/Yym/tXxZVYdEZElspXAja2e29kr6ej3ye8oKNTgpxe6omN4bXN3iYiIyO6lVmem1Pz58zFjxgwkJCSgTZs2mDdvHjp37lzq8T/++CPeeustnDt3DlFRUZg+fToGDx5s8tgXXngBn3/+OT755BOMHz/eegdVclkTjxYHqC7sATQFxa+7egORPbUBKima7lfPnL2laiK/XpdTslVwSrKpJKtKglZZeQZ/ForU9XM3Wu2vVT0/eLlxLQIiInOzuDFGFbKFcxuz9AB+++syejcNxqKnOpm7O0RERITyjzEq/C/eZcuWYcKECViwYAG6dOmCOXPmYMCAAThx4gSCg2+ev79z50488cQTmDZtGu69914sXboUDz74IA4cOICWLVsaHbtixQrs3r0boaGh1v8lStp4SEttu3sCkHUDOLtZG6CSlpEExPyqbSK4RfE0v7DOgJOLuc+AqoBMHwj191BtcKu6al9+QSFOJaXrA1XyeDIxTQWvLqckYPWRBHWcLOrXpE7xtD95jAr2hjNXEyIiIlKkvqMEpGTYNXFANK8KERGRlalwppQEojp16oRPP/1UPS8sLERYWBheeuklTJo06abjhw4dioyMDPz6a1HwBcAdd9yBtm3bqsCWTnx8vPrstWvX4p577lFZUladKVWWwkIg4U/g1AZtJtXFfZJTU/y6mx/QqFdRFlVfwCfEnL2lGpCRk4/D8SlGgSoJUpXk6eqElvX8VF0qXaBKMqxYO4OIqPpU1RijIpnmeXl56obekiVL1BgpOjpaZZoPHDjQ5PEfffQRJk+ejHHjxqkbhjV9buYyYtFebD15BQ+0DcXcx9uZuztERERUnZlSubm52L9/vxr06Dg6OqJv377YtWuXyffIfsmsMiSZVStXrtQ/l8DWk08+iYkTJ6JFixbl6ktOTo5qhidsNRwdgdB22tZjIpBxFTizSRugOr0ByLoGHFupbaJuG20GlUzzq98RcORKbrZGpundERmgmk5iavG0P3n862IK0nPysTf2mmo6QT5uRqv9tarvB193ZtoREVmSimaaT5kyBd988w0WLlyIpk2bqpt2Q4YMURno7doZB1/27dunSh+0bt0a9mTP2asqIOXs6IAJ/ZqYuztERERUCRUKSiUnJ6OgoAB16tQx2i/PY2JiTL5H7gaaOl7268idP2dnZ7z88svl7ovcPXz33XdhE7wCgNaPalthAXDpYFEtqnXa7ct/atvvMwCPWkCjPkVBqj6AV6C5e0/VRAqfD2gRopqQAq5SzNVwtb+YhDRVSH39sUTVhExhkNX9DFf7iw7xgQun/RERmc3s2bMxatQojBw5Uj2X4NRvv/2GRYsWmcw0//rrr/Hmm2/qa3COHj0aGzZswKxZs1SwSic9PR3Dhg1Twav/+7//g72QRP+P155Q20M7haFhgJe5u0RERESVYPYqypJ5NXfuXFVjqiJTkCRbyzADSzKlZBqh1ZMsKMmGktbrDSA9CTi9URugOrMRyLoOHPlJ2+AA1GuvDVDJVL+67bRZWGSTnBwdEFXHR7XHOmr/rGflFuDoJePV/i5ez8LppHTVftp/UR3n5uyopv0ZBqrq1/LgtD8iohpQmUxzyQZ3dzdeldXDwwPbt2832jdmzBhV9kA+y56CUhuPJ2H/+etwd3HEy32izN0dIiIiqomgVGBgIJycnJCYqM3I0JHnISGm6x7J/rKO37ZtG5KSktCgQQP965KN9Y9//EOltsuKfaa4ubmpZvO8g4G2T2hbQb62/pSa5rceSDgMxO/Xti3TAM/A4jpUjXoDnlwS2dZ5uDqppa8Nl7+WzKm/LhYHqSSrKjU7Xw3epekEeLnq61Kpx/r+8PPktD8ioqpWmUxzmdon2VXdu3dHo0aNsHHjRixfvlx9js7333+vburJ9L3ysuryB0UKCzWYuU6bJTWiW7jKLCYiIiI7CEq5urqiQ4cOamAkK+jp6kHJ87Fjx5p8T9euXdXrhkXL169fr/YLqSUld/dKDsRkvy7FnYo4OQMNu2pb37eB1EvaGlQqi2oLkJkM/Pmdtjk4AvU7F6/oF9JKO6+LbJ7UmOrTrI5qusH7uasZRkGqY5dTcTUjF5tiklTTiQj00gap6vuhbYNaaFbXB27OrGFGRFTTJItcpvtJPSnJJJfAlIyLZLqfuHDhgipqLmOqkhlVtl7+4Jc/L6np6z7uzhjdo5G5u0NEREQ1OX1PpsyNGDECHTt2VCvGSDaTrK6nCyANHz4c9erVU4MeIQOmHj16qBoIkl4ud/X++OMPfPHFF+r1gIAA1Qy5uLioTCpZaYbK4BsKtB+ubfm5wIU9RbWo1gNXjgMXdmvbpvcB7xAgqq82QBXZE3D346W1E46ODogM8lbtofb11b7svAIcv5xqVEj93NVMxCZnqLbiYLw6ztXJEc1CfYtW+5Ppf7UQHuDJaX9ERNWcaR4UFKQWhcnOzsbVq1cRGhqqak9FRkaq12U6oGSat2/fXv8eyaL6/fff1QrJkg0lP9PWyh/k5hdi9vqTavuFHo3g7+lq7i4REZEVkyQbmWZPFSdxG1NjjWoPSg0dOhRXrlzB1KlTVbHytm3bYs2aNfqU9Li4OFUnQadbt25YunSpWkXmjTfeQFRUlBpktWzZ8rY7T4bfpCsQcbe29X8fuHFBO8VPAlRntwDpCcDBb7TN0Rlo0FU7zU+CVMHNmEVlZ9xdnNCuQS3VdK5n5OLPoml/ukDV9cw8tS1Nx8/DRT/tr22YH9rU90eAtx1MpSUiqqTKZJrrSBaU3OzLy8vDzz//jMcee0zt79OnDw4fPmx0rNwglMyq119/vdRBorWXP1j2xwXEXctEoLcbRt4Zbu7uEBGRFZNgVGxsrPo7mSrH399f3WCrSH3wkhw0snyJDZA7fX5+fkhJSYGvr6+5u2NZ8nOA8zu0ASppV08Zv+5bv3iaX0R3wM3bXD0lCyL/a5CBv+G0vyOXUtVd6pLCanuoLCpdoKpFqJ8KfBER2YKqGGMsW7ZMZZp//vnn+kzzH374QdWUkht7JTPN9+zZg/j4eHXzTx7feecdNXCWGlIyADSlZ8+e6nj57Jo8t5oii3t0n7FZ1U589/4Wqp4UERFRpf+tExenbvpINrJhYg2V7/plZmaqrG0Zl9StW7fSYwyzr75HNcDZTVv4XNrAacC1s8CpolpU57YBqReB/Yu1zckVaNitaEW//kBAY2ZR2SmJdssS29IeaFtP7ZOA1ImENBy6cB0HiwJVZ65k4MK1LNX+9+cldZyzowOa1vUpqk/lj3YN/BEZ6K2mEhIR2aOKZprLtD3JMj979iy8vb0xePBgfP3116UGpOzB4p2xKiAlq8c+0bl4gRwiIqKKys/PV0EVCUh5enryAlaCrAosJDAVHBxc6al8zJSyd3lZwLnt2gDVybXAjfPGr9cKBxoXZVGF3wW48heWjKVk5eHwxRQVqDp0QR5vIDm9eGUnHR83Z7RWdam0gaq2DfwR7MMVk4jI8llTNpGtnltKZh7u/niTWk129mNt9DUSiYiIKkNu/kgGcnh4uD64QhWXlZWFc+fOISIi4qaFV5gpReXj4lE0da8fMOhj4Orp4mLpMuXv+jlg30Jtc3YHwu8uyqLqC9TWFlsl+yY1pu6KClRNl8oZfyMLf6oA1XX1+Ff8DaTl5GPH6auq6YT6uavglApShfmjVX0/eLoygZOIiIx9/vsZFZBqUsdbn71LRER0u26nFhKhSq4f//VHxeQPVGCUtnUdA+SkA7G/FwepZJqfFE+XtlqWTmxcFKDqBzS8UztNkOye/I+pfi1P1e5prZ1bnF9QiBOJaUaBqpNJabiUko1LhxOw6nCCOk5m9zWp46Om++myqaKCfeDEaX9ERHYrKS0bi3ecU9uv9o/m3wlERERVQLLExo8fr5o5MShFpZOC500Ha5vUw78SUxygitulzaqStvtfgIsnENGjOOvKn7UeyOB/NE6Oqvi5tL910f7ZSM/JL5r2d0MfqEpIzUZMQppq3+29oI7zdHVCq3p+KkDVtihQVdePKbZERPbi002nkZVXoG5Y9GuurcFFRERkj3pWYlGT0uzbtw9eXl4wNwalqPxZVMHNtO3OcUB2KnB2S3GQKj0BOLla20RQs+IAVdgdgLMrrzQZ8XZzRtdGAarpJKRkG63299fFG8jILcCe2Guq6dTxddNnUkmgSqb9+bi78AoTEdmYuKuZ+G5vnNqeOCCa0yyIiIjKIKVUCgoK4Ox861BPUFAQLAELndPtkyyqhMPaANXpDcCFPYCmsPh1Vx+gUU/tVD8pmu5783KRRKYUFGpwOildBah0q/3JNEDZb/Q/MgegcZC3toh6mLY+VXSID1ycuLQrEdlPMXBbPLdXlh3CioPxuDsqEF8/08Xc3SEiIhsrdG6qQLeleuqpp7BkyRKjfYsXL8bIkSOxatUqtWrv4cOHsW7dOoSFhWHChAnYvXs3MjIy0KxZM0ybNg19+/YtdfqelGFZuHAhfvvtN6xduxb16tXDrFmzcP/991fqOrLQOdUciQjUba1t3V8FMq8BZzdrM6ikZSYDx/+nbaJOq6Isqv5A/U6AExP2yDSpJSXBJWmPdQpT+zJz83EkPlUFqHRZVVJY/VRSumo/7r+ojnN3cUTLUD+jQJUsI85ihkRE1iEmIRUrD8Xrs6SIiIiqM8NIpoqbg4eLU7n+jTJ37lycPHkSLVu2xHvvvaf2HT16VD1OmjQJM2fORGRkJGrVqoULFy5g8ODB+OCDD+Dm5oavvvoK9913H06cOIEGDUovtfPuu+/i448/xowZMzBv3jwMGzYM58+fR+3atVFdGA2gqudZG2j5sLYVFgKXDxUFqNYB8fuBxMPatn024O4HNOqjDVI17gt4B/MbobL/eLk6o3NEbdUMi+D+pYqoF039u3gDadn5+OP8ddV0Ar1d9Sv9SaAr2NcdQT5uCPJ2g6szs6qIiCzJzLUnVTL24FYhaF3f39zdISIiGyYBqeZT15rlZx97b0C5ViCXzGZXV1d4enoiJCRE7YuJiVGPEqTq16+f/lgJIrVp00b//P3338eKFSvwyy+/YOzYsWVmYz3xxBNq+8MPP8Q///lP7N27FwMHDkR1YVCKqpejI1Cvvbb1fB3ISAZObyxaxW8DkHUdOLpc20Rou6IV/fprtx2d+A3RLQX7uKNvc2naAriFhRqcTc4wyqY6fjkVyem52BiTpFpJ/p4uCJYAlY+b+jxdsCrY1/DRHb4ezsy2IiKqZvvPX8eG44lqVdYJ/ZglRUREVJaOHTsaPU9PT8c777yjpuJdvnwZ+fn5yMrKQlyctk5jaVq3bq3fliLoMrU/KenmfztVJQalqGZ5BQJthmpbYYE2c0qXRSUZVZcOatvW6YBHbW32lKpF1UebgUVUDo6ODmgc7K3awx3qq33ZeQU4eql42t/5qxlISsvBlbQc5BdqcCMzT7WTiellfrZkVBkGqwyDWPqglq8bAryYfUVEVNkpFB+v0d75faRDffX/ciIiouqeQicZS+b62ber5Cp6r776KtavX6+m9DVu3BgeHh545JFHkJubW+bnuLgYLx4l0woLZfZTNWJQisxHsqDCOmtb7zeBtERt9pQEqM5sBrKuAYd/0DYHybjqWLyiX0gbbRYWUTm5uzihQ8NaqhmSrKobWXkqOCVNpgJqH42fS0vNzkdufqGqYSXtVmp7uRoErrSPuqYPZPm6wceN2VdERDq/n0pWK666OjliXN8mvDBERFTtJPhSnil05ubq6qpW17uVHTt2qKl4Q4YM0WdOnTt3DpbI8q862Q+fOkC7YdpWkAdc3KcNUEkmVeIR4OJebdv8AeAVXBygiuwFeLDWBFU+q0qCR9KkzlRZJNvKMGB1pUQA60p6DpJSc5Ccrs2+upaRq5qsGFgWN8m+Msy0Kpl5VfQ8wNuVKwoSkU2TGwUz1mqzpP5+R0PU8/cwd5eIiIgsRnh4OPbs2aMCTN7e3qVmMUVFRWH58uWquLkE3N56661qz3iqLAalyDI5uQANu2lb33eAlHhtHSoJUJ3dAmQkAYe+1TYHybjqUryiX50W2hUBiaoh2yqstqdqt/pH1fXMXH2QyjBgpX3MVo9XUnOQlpOPnPxCXLyepVpZ5I91bU9X0xlXRvvc4M3sKyKyQquPJKgVVr1cnTCmVyNzd4eIiMiivPrqqxgxYgSaN2+uakQtXrzY5HGzZ8/G008/jW7duiEwMBCvv/46UlNTYYkcNDJx3wbIBZZq9CkpKaoYF9mw/FwgbldxFlXyCePXfUKBqKJaVJE9Abeys1+IzCkrV5t9dSW9xLRBXQCrKBtLirQXFJb/f9fuLo4mMq5uDmYFeLnC2YlTYYnsdYxhSeeWX1CI/nN+x9krGRjXJwqv9OPUPSIiqh7Z2dmIjY1FREQE3N3deZmr4TqWd4zBTCmyPs6uQGQPbRvwAXD9fHEWVezvQNol4MBX2uYoGVddgcZFWVRB0cyiIovi4eqEBgGeqt0q++qaZF+VUu9K9iUXPabn5CM7rxBx1zJVu1X2lQSmgkpmXBmtPKh9TbKviIiqy88HLqqAVC1PFzx7dwQvNBERkR3gvzDI+tVqCHR6VtvysoHzO4pX9Lt2Rhuokrb+LcCvQfE0v4i7AVfjVQqILLn2VaC3m2rN6pZ9bGZuvlGwqrQi7lL7SpKvJAtL2vHLZX+up6uTicCVu7aYuz6ApV150EnWcSciKiep2Tdnwym1PaZXY/i4G6/+Q0RERLaJQSmyLS7uQOM+2jboI+DqmeIV/WK3ASlxwB//0TYnNyD8Tm2ASloAa1eQbZCVQxoGSCs76CrTAaUQu6mAlb4V1cDKyC1AZm4Bzl/NVK0sEo8KkEBViZUHtY/uBhlYblaxygkRVb9vdp/H5ZRs1PVzVwXOiYiIyD7wXwNk2yTQJK3L80BuJnBuW1EtqnXAjTjgzCZtWzMJqB2pneYX1hnwrgN4BwNeQYBHLU75I5sk2Uy6GlPNUXYtmYycouwrffH27JtWHZTHq0XZV7qgFm6RfSXFjA1rXBkWazfcL6sjMvuKyDalZedh/ubTant83yi1qAQRERHZBwalyH64egJNBmib1PdPPlUcoDq/E7h2Ftj7ubYZkrpUEpzyDgK8go23dYEr9RgMeNYGHDmYJtvj5easWnjgrbOvrmYUB6kMs64Ms7Hk9ay8ApWBlXE1E+dukX0lASlt7aubA1Yl90mdLiKyHv/eFovrmXmIDPLCw+3rm7s7REREVIMYlCL7JNWdg5poW7exQE6atu6UBKiunAQykoD0K0BOClCYpy2eLu2Wn+sIeAYUBaxMBa6CjLedWDODbIsEjyQwJO1WpCB7afWuDKcRSpBLgl0qmJWWg6O3+FwpyC5BqkBp3q7w93RVhZNrebrCz0P7WMvLBX4e2v2yjysQEpmHZFf+e9tZtf2PftH8XSQiIrIzDEoRCTcfoOk92mZICqdnJgPpSUDGlaLHooBVhm5f0XbmNUBTqN0nLakcl1amBuoDV4EmglkGz6VeFpENkeCRtIhbZF/JMvFS+6q0VQf12Vdp2WrVQQl2STubnFHuvvi4O2uDVZ4uKojlXxTEkkd/CWR5aYNbalsevVzg4+YMBwlwE1Gl/WvLGZUx2bKeLwa1DOGVJCIisjOVCkrNnz8fM2bMQEJCAtq0aYN58+ahc+fOpR7/448/4q233sK5c+cQFRWF6dOnY/Dgweq1vLw8TJkyBatWrcLZs2fh5+eHvn374qOPPkJoaGjlz4yoKkggyK++tt1KQb5BAEsXuCoKWOkCV/pgVjKgKQCyrmtb8olbf76rj0HAqkQWlmH2lTy6erMOFtkMyWKSVf6klUWj0ZTIvspRwazrmbm4kZmnf7yRKfu0j6nZ+eq9adn5qsVdq1hWmASpjAJYpgJb6hhtdpa/hyunFxIVib+Rha93nVfbEwc0VauMEhERkX2pcFBq2bJlmDBhAhYsWIAuXbpgzpw5GDBgAE6cOIHg4OCbjt+5cyeeeOIJTJs2Dffeey+WLl2KBx98EAcOHEDLli2RmZmptiVoJQGu69evY9y4cbj//vvxxx9/VNV5ElU/J2fAJ0TbbqWwUBuMUoGqcmRhFeQCuWnANWnaaQ5lcvYoXw0s2e/uzwAW2QTJWpJl5KVFBnmX6z2ShZWSlYcbWUXBqgxt8Er2XS8KXqVkGm5rH6UelrZ+Vq5qQPmzstycHQ2CWLqAli6IVRTQKsrO0k4v1L7m4uR4G1eHyPLM3XASuQWF6BJRG92jAs3dHSIiIjIDB43cWq4ACUR16tQJn376qXpeWFiIsLAwvPTSS5g0adJNxw8dOhQZGRn49ddf9fvuuOMOtG3bVgW2TNm3b5/KvDp//jwaNGhQrn6lpqaqLKuUlBT4+pa9ihSRVZFf0ewU48CVZFqVDGLpglt5ZReMvknJQu6l1sBiIXciney8Am3WVZY2kCUBLQlsmcrG0mZpabfzZWnCSpLpgn4GWVk3Z2fptounGcq0RGaf3D5bHmOY69xOJ6Wj/ydb1WqdP4/uhg4Na9XYzyYiIsrOzkZsbCwiIiLg7m4/ZVLCw8Mxfvx41ar7OpZ3jFGhTKnc3Fzs378fkydP1u9zdHRU0+127dpl8j2yXzKrDElm1cqVK0v9OdJpuePt7+9fke4R2SapWePhr22BUbc+Pie9uK6VycBV8m0Wcg8sfdqg4dRCqZHFQu5ko2TJ+hA/aeUfxOimF2qDVkUBLIMMLQlw3TCRlZWanadi02k5+apdvJ5V7p8ps6F0xd11gSxdYEtlYZUsAl+UneXh4sR6WVStZq8/oQJSfZvVYUCKiIjIjlUoKJWcnIyCggLUqVPHaL88j4mJMfkeqTtl6njZX1qk7fXXX1dT/sqKpuXk5KhmGIUjIpkb5K1ttSNufTmkkHvJuleG0wYNpxZm6Qq5FwW6UNFC7qVkX7GQO9nh9MKw2uV/n0wTTDWcTphlepqhLitLF9jKzC1Q/+iX16RVhKuzY3FR93JMM9QWhHdV7yO6lcMXU7DqcIK65zJxQDQvGBERkR2zqNX3pOj5Y489pu4mf/bZZ2UeKzWq3n333RrrG5HNFnL3D9O2WynIAzKvlj5t0DALqzKF3N18DYJVupUITWVhBbGQO9kVKaiuMpi8XCv0vpz8gqJ6WMbTCdWjZGVllMjWKno9r0CD3PzCohUNi2/+lIeXq5NRUffyTDP09XBR50j24+O12huZD7ath+gQH3N3h4iIyCp88cUXeOedd3Dx4kU1Y03ngQceQEBAAN588001S2337t2qhFKzZs1U3ERmttlMUCowMBBOTk5ITEw02i/PQ0JMF3eW/eU5XheQkjpSmzZtumVdA5lCaDgtUDKlpLYVEVUTmYpXoULu126xEqFBMEumEOakatu1MxUr5F4ycCUBLRZyJ4KbsxOCfaVVbIqhZFgV18bS1ckyro1Vsn6WPJcphhm5BcjIzVKrqpWXg8EUQ+1j+aYZSgBMss/Iuuw8k4xtp5Lh7OiAV/o2MXd3iIiItGQgU9HavFXFxbNcC089+uijqpb35s2b0adPH7Xv2rVrWLNmDVatWoX09HQMHjwYH3zwAdzc3PDVV1/hvvvuU4vSlbdWt8UHpVxdXdGhQwds3LhRraCnK3Quz8eOHWvyPV27dlWvGxbSWr9+vdpfMiB16tQpdYElyncrcpGlEZEFksi9ynaS1ZSal6OQ+42yi7frM7GKCrnnZwE34rTtVpxci6cMGk4hlBpdzu6As1vxo5PBtnp0NX7uZPDc0anKLheRpZAgj5ebs2r1K1B3ulCmGGYbBK30wSzD7CzddnHAS2psyf8CdM8rwsXJQa1MqAtWzXy0DRoEeFb8pKnGSNDz4zXazNknOjfg90VERJZD/o3xYah5fvYblwBXr1seVqtWLQwaNAhLly7VB6V++uknlTzUq1cvlT3Vpk0b/fHvv/8+VqxYgV9++aXUeI1VTt+T7KQRI0agY8eOaoW8OXPmqNSwkSNHqteHDx+OevXqqTQxMW7cOPTo0QOzZs3CPffcg++//x5//PGHSj3TBaQeeeQRHDhwQK3QJzWrdPWmateurQJhRGTrhdxraVu5C7mXVrzdcCqhFHJPBQpygdR4batKsmrhrQJXpl4v1zHlCZBJYIz1e8gyyAp/2npT8nf2rQdVOjJNUKYS6qYZqjpZmabrZ+lXO8zMU++TaYbJ6TmqaftQjSdIVWL9sUQcunBDFdJ/qXdjXlUiIqIKGjZsGEaNGoV//etfKknn22+/xeOPP64CUpIpJdP7fvvtN1y+fBn5+fnIyspCXFw5buRbU1Bq6NChuHLlCqZOnaqCR23btlXpYrpi5nLChvMbu3XrpiJ5U6ZMwRtvvIGoqCi18l7Lli3V6/Hx8SpyJ+SzDEnWVM+ePW/3HInIJgu5R1aukLsuYJUtAascIF9adtGj4Xa2NqBl+FwKvevIlMNcaTAffWCsHJldRq9XURCNgTG6TVIYPdjHXbWKZNtk5RWUyMbKQ5APs6ctmRTsn7lOmyU18s7wCk0rJSIiqpEpdJKxZK6fXU4yHU/GQhJ46tSpE7Zt24ZPPvlEvfbqq6+qWWkzZ85E48aN4eHhoRKAcnPN+Q+Waip0LqlfpaV/bdmyxeTcR2mmhIeHq4tKRGTWQu63Iv+fKswvEbwyEbjKL/m8HMfc9HopAbI8qdOjMREYS4PZSMBKZXVVYOqj/tGtYkE0p1LewxQZu5ti6OnqrFqov4e5u0Pl9N9D8TiZmA5fd2c8370RrxsREVne7I1yTKEzN3d3dzz00EMqQ+r06dOIjo5G+/bt1Ws7duzAU089hSFDhqjnkjl17tw5WDqLWn2PiMii/6KSYu/SJFPLHPSBMcPAVlHg6qasr/IcU1Z2WBnHGAbG5Hhp5g6MlRa4UkGzou9NBbCcjfdJtpnJ50XHqefleb+J4029JrXIWJyb7IxMt5y9/qTafqFnI1XEnoiIiCpHpvDde++9OHr0KP7+97/r98ustOXLl6tsKrmJ99Zbb6ka4JaOQSkiIqsMjMECAmOmAmGlBb/KkxlW8jPKyC4zFRjTlhaycA6VC3Dd7vG3/VlyDIs23a758+djxowZqvyBFCKdN2+eqs9pitTclPqcS5YsUaUO5E7o9OnTMXDgQP0xn332mWq6u6AtWrRQ5RWkCKol+W5vHC5ez1JTLEd2izB3d4iIiKxa7969Vf1tWVXvb3/7m37/7Nmz8fTTT6sSSlL8/PXXX0dqaiosHYNSRERUycCYj4UExm4R/CrI0x6vgld5Rc/zip4X7VfPdS3X+Pjbea+moGTni4No1sbB6TYDZFUdjCvx3L+BdsqnhVq2bJlaLGbBggXo0qWLWihmwIABakAZHBx80/FSi/Obb77BwoUL0bRpU6xdu1al4+/cuRPt2rVTx9SvXx8fffSRujMqpRAkgPXAAw/g4MGDKkBlCTJz8zFv02m1/XKfKHi4cuVSIiKi2+Ho6IhLly6ZLI20adMmo31jxowxem6J0/kcNDZS0EkigH5+fkhJSYGvr6+5u0NERARIyrQ+iFWJoJb++LJeq+hnlfN4w2w0a/DSASCgkcWOMSQQJQVJP/30U/Vc0unDwsLw0ksvYdKkSTcdHxoaijfffNNoMPnwww+roqUSrCqN3DmVbKxnnnmmxs6tLPM3n8aMtSfQoLYnNkzooYrbExERmVt2djZiY2MRERGh6jRR1V/H8o4xmClFRERUXWTKm2NRnStrorLRCoyDWFUSXCvr+PIG50r5LMmWslCy6s3+/fsxefJko7ucffv2xa5du0y+Jycn56bBnQSktm/fbvL4goIC/Pjjj8jIyEDXrl1hKeTep5uzIyb0a8KAFBEREd2EQSkiIiIyMU1Tps05Ay5c4e52JScnq6BRnTp1jPbL85iYGJPvkal9Uhuie/fuaNSoETZu3KiKl8rnGDp8+LAKQsmdSm9vb6xYsQLNmzcvtS8S7JKmU921Jsb2jsJjHcMQ6G1lgVkiIiKqEcyhJiIiIrIwc+fOVbWipJ6Uq6srxo4di5EjR6oMK0NSAP3QoUPYs2cPRo8ejREjRuDYsWOlfq4UT5dUel2TKYTVLdjXHY6ODtX+c4iIiMj6MChFREREVI1kBRwnJyckJiYa7ZfnISEhJt8TFBSElStXqul458+fVxlVkgkVGRlpdJwErBo3bowOHTqogJOs6icBrdLIFEKp7aBrFy5cqKKzJCIiIqo4BqWIiIiIqpEEjiRoJFPwdKTQuTy/Vf0nqStVr1495Ofn4+eff1ar65VFPtdwel5Jbm5uqtioYSMiIrJXNrLum1VfP9aUIiIiIqpmEyZMUFPrOnbsiM6dO2POnDkqC0qm5Inhw4er4JNkOwmZjhcfH4+2bduqx3feeUcFnF577TWjrKdBgwahQYMGSEtLw9KlS7FlyxasXbuW3ycREVEZJINZtxiJLCRClZOZmakeXVxcKvkJDEoRERERVbuhQ4fiypUrmDp1KhISElSwac2aNfri53FxcUb1oqRw+ZQpU3D27Fk1bW/w4MH4+uuv4e/vrz8mKSlJBbMuX76s6kO1bt1aBaT69evHb5SIiKgMzs7O8PT0VH83S0ClZM1GunWGlASkZCwiYxNdkK8yHDQ2kq8mq8fIgEzqIzAVnYiIiDjG4PiJiIioNJIlFRsbqzKRqXIkICX1MR1k5eZKxmg4fY+IiIiIiIiI7K7mo6x0K8EpqjjJMLudDCkdBqWIiIiIiIiIyO7ItD1ZVITMhxMniYiIiIiIiIioxjEoRURERERERERENY5BKSIiIiIiIiIiqnE2U1NKt4igVHgnIiIiqiq6sYWNLFhshOMnIiIiMuf4yWaCUmlpaeoxLCzM3F0hIiIiGyRjDVna2JZw/ERERETmHD85aGzktl9hYSEuXboEHx8fODg4VEuUTwJeFy5cgK+vL+wBz5nfs63in23+2bZV/LNdPX+2ZagkA6rQ0FC1So8tqe7xk+CfS/4/11bxzzb/bNsq/tnmn+2aHD/ZTKaUnGT9+vWr/edIQMpeglI6PGf7wO/ZPvB7tg/8nquerWVI1fT4SfDPpX3g92wf+D3bB37P9sG3GmMc5Rk/2dbtPiIiIiIiIiIisgoMShERERERERERUY1jUKqc3Nzc8Pbbb6tHe8Fztg/8nu0Dv2f7wO+ZLBH/XNoHfs/2gd+zfeD3bB/cLCTGYTOFzomIiIiIiIiIyHowU4qIiIiIiIiIiGocg1JERERERERERFTjGJQiIiIiIiIiIqIax6CUgfnz5yM8PBzu7u7o0qUL9u7dW+bF+/HHH9G0aVN1fKtWrbBq1SrY8jl/+eWXcHBwMGryPmvy+++/47777kNoaKjq/8qVK2/5ni1btqB9+/aqAFzjxo3VdbDlc5bzLfk9S0tISIA1mDZtGjp16gQfHx8EBwfjwQcfxIkTJ275Pmv+fa7MOVv77/Nnn32G1q1bw9fXV7WuXbti9erVNvsdV+acrf07NuWjjz5S5zF+/Hib/q6tDcdPHD+ZwvGTdY2fBMdQHEPZ6t+r9j6G+sjCx08MShVZtmwZJkyYoKrPHzhwAG3atMGAAQOQlJRk8sLt3LkTTzzxBJ555hkcPHhQ/SNQ2pEjR2Cr5yzkl/jy5cv6dv78eViTjIwMdZ4ygC6P2NhY3HPPPejVqxcOHTqkfpGfffZZrF27FrZ6zjoS1DD8riXYYQ22bt2KMWPGYPfu3Vi/fj3y8vLQv39/dR1KY+2/z5U5Z2v/fa5fv776C3b//v34448/0Lt3bzzwwAM4evSoTX7HlTlna/+OS9q3bx8+//xzNagsiy1819aE4yeOn0zh+Mn6xk+CYyiOoWz171V7HkPts4bxk6y+RxpN586dNWPGjNFfioKCAk1oaKhm2rRpJi/PY489prnnnnuM9nXp0kXz/PPP2+w5L168WOPn56exFfLHf8WKFWUe89prr2latGhhtG/o0KGaAQMGaGz1nDdv3qyOu379usYWJCUlqfPZunVrqcfYwu9zRc/Z1n6fRa1atTT//ve/7eI7Ls8529J3nJaWpomKitKsX79e06NHD824ceNKPdZWv2tLxfETx0+mcPxkGziG0tj83686HEPZ5necZiXjJ2ZKAcjNzVVR0759++qDdY6Ojur5rl27TAbzZL/h8UKyjEo73hbOWaSnp6Nhw4YICwu7ZXTZFlj793w72rZti7p166Jfv37YsWMHrFVKSop6rF27tt18z+U5Z1v6fS4oKMD333+vMsMkHdsevuPynLMtfceSCShZqyW/Q3v4ri0Zx09aHD/dzJ5/D21l/CQ4hoLN//3KMZRtj6HGWMn4iUEpAMnJyeoXsk6dOkYXR56XNg9c9lfkeFs45+joaCxatAj//e9/8c0336CwsBDdunXDxYsXYatK+55TU1ORlZUFWyQDqQULFuDnn39WTf5H3LNnTzXF09rIn1GZcnnnnXeiZcuWpR5n7b/PlTlnW/h9Pnz4MLy9vVW9txdeeAErVqxA8+bNbfo7rsg528J3LCT4Jv//kVon5WEr37U14PipGMdPxjh+su7xk+AYimMoW/t71d7GUN9b0fjJudp/AtkMuRtveEdefjGbNWum5qi+//77Zu0bVR35n7A0w+/5zJkz+OSTT/D1119b3d0BmQe9fft22IvynrMt/D7Ln1Op9SZ3cn/66SeMGDFC1cMobYBhCypyzrbwHV+4cAHjxo1TtdKsucAo2Tdb+F0k+xo/CY6hbPt3mmMo2x5DXbCy8RODUgACAwPh5OSExMREo4sjz0NCQkxeONlfkeNt4ZxLcnFxQbt27XD69GnYqtK+Zyl85+HhAXvRuXNnqwvsjB07Fr/++qtafVCKG5bF2n+fK3POtvD77OrqqlbEFB06dFCFHOfOnasGDLb6HVfknG3hO5Zp5rL4hqyAqiNZvvJn/NNPP0VOTo76u8wWv2trwPFTMY6fjHH8ZL3jJ8ExFMdQtvj3qj2NofZb2fiJ0/eK/oDKH8yNGzfqL4yk6Mnz0mp1yH7D44VEIsuq7WHt51yS/MGWNEiZ7mWrrP17riqSmWEt37PUc5fBlKTkbtq0CRERETb/PVfmnG3x91n+HyZ/ydrid1yZc7aF77hPnz6qz/L/IF3r2LEjhg0bprZLDqhs+bu2RBw/aXH8dDP+Hlrf+ElwDMUxlD39PtvyGKqPtY2fqr2UupX4/vvvNW5ubpovv/xSc+zYMc1zzz2n8ff31yQkJKjXn3zySc2kSZP0x+/YsUPj7OysmTlzpub48eOat99+W+Pi4qI5fPiwxlbP+d1339WsXbtWc+bMGc3+/fs1jz/+uMbd3V1z9OhRjTWtQHDw4EHV5I//7Nmz1fb58+fV63K+ct46Z8+e1Xh6emomTpyovuf58+drnJycNGvWrNHY6jl/8sknmpUrV2pOnTql/jzLKg2Ojo6aDRs2aKzB6NGj1WoZW7Zs0Vy+fFnfMjMz9cfY2u9zZc7Z2n+f5VxkdcHY2FjNX3/9pZ47ODho1q1bZ5PfcWXO2dq/49KUXD3GFr9ra8LxE8dPguMn6x8/CY6hOIay1b9XOYbSWPT4iUEpA/PmzdM0aNBA4+rqqpY43r17t9GXOGLECKOL98MPP2iaNGmijm/RooXmt99+09jyOY8fP15/bJ06dTSDBw/WHDhwQGNNNm/erAIzJZvuPOVRzrvke9q2bavOOzIyUi0RasvnPH36dE2jRo3UP15r166t6dmzp2bTpk0aa2HqXKUZfm+29vtcmXO29t/np59+WtOwYUPV/6CgIE2fPn30wRlb/I4rc87W/h2Xd1Bli9+1teH4ieMnjp+sf/wkOIbiGMpW/17lGEpj0eMnB/lP9edjERERERERERERFWNNKSIiIiIiIiIiqnEMShERERERERERUY1jUIqIiIiIiIiIiGocg1JERERERERERFTjGJQiIiIiIiIiIqIax6AUERERERERERHVOAaliIiIiIiIiIioxjEoRURERERERERENY5BKSKicnJwcMDKlSt5vYiIiIgqgGMoIioNg1JEZBWeeuopNaAp2QYOHGjurhERERFZLI6hiMiSOZu7A0RE5SUBqMWLFxvtc3Nz4wUkIiIi4hiKiKwQM6WIyGpIACokJMSo1apVS70mWVOfffYZBg0aBA8PD0RGRuKnn34yev/hw4fRu3dv9XpAQACee+45pKenGx2zaNEitGjRQv2sunXrYuzYsUavJycnY8iQIfD09ERUVBR++eWXGjhzIiIiosrjGIqILBWDUkRkM9566y08/PDD+PPPPzFs2DA8/vjjOH78uHotIyMDAwYMUEGsffv24ccff8SGDRuMgk4S1BozZowKVkkASwJOjRs3NvoZ7777Lh577DH89ddfGDx4sPo5165dq/FzJSIiIqoqHEMRkdloiIiswIgRIzROTk4aLy8vo/bBBx+o1+V/Zy+88ILRe7p06aIZPXq02v7iiy80tWrV0qSnp+tf/+233zSOjo6ahIQE9Tw0NFTz5ptvltoH+RlTpkzRP5fPkn2rV6+u8vMlIiIiqgocQxGRJWNNKSKyGr169VLZTIZq166t3+7atavRa/L80KFDalsyptq0aQMvLy/963feeScKCwtx4sQJNf3v0qVL6NOnT5l9aN26tX5bPsvX1xdJSUm3fW5ERERE1YVjKCKyVAxKEZHVkCBQyel0VUXqTJWHi4uL0XMJZklgi4iIiMhScQxFRJaKNaWIyGbs3r37pufNmjVT2/IotaaktpTOjh074OjoiOjoaPj4+CA8PBwbN26s8X4TERERmRPHUERkLsyUIiKrkZOTg4SEBKN9zs7OCAwMVNtSvLxjx46466678O2332Lv3r34z3/+o16TguRvv/02RowYgXfeeQdXrlzBSy+9hCeffBJ16tRRx8j+F154AcHBwWoVv7S0NBW4kuOIiIiIrBXHUERkqRiUIiKrsWbNGtStW9don2Q5xcTE6FfG+/777/Hiiy+q47777js0b95cvebp6Ym1a9di3Lhx6NSpk3ouK/XNnj1b/1kSsMrOzsYnn3yCV199VQW7HnnkkRo+SyIiIqKqxTEUEVkqB6l2bu5OEBHdLqnttGLFCjz44IO8mEREREQcQxGRFWBNKSIiIiIiIiIiqnEMShERERERERERUY3j9D0iIiIiIiIiIqpxzJQiIiIiIiIiIqIax6AUERERERERERHVOAaliIiIiIiIiIioxjEoRURERERERERENY5BKSIiIiIiIiIiqnEMShERERERERERUY1jUIqIiIiIiIiIiGocg1JERERERERERFTjGJQiIiIiIiIiIiLUtP8HKrNeasJnvnwAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Visualizamos una predicción de ejemplo\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 4))\n",
+    "\n",
+    "axes[0].plot(history.history['loss'], label='train')\n",
+    "axes[0].plot(history.history['val_loss'], label='val')\n",
+    "axes[0].set_title('Binary cross-entropy')\n",
+    "axes[0].set_xlabel('Epoch')\n",
+    "axes[0].legend()\n",
+    "\n",
+    "axes[1].plot(history.history['bin_acc'], label='train')\n",
+    "axes[1].plot(history.history['val_bin_acc'], label='val')\n",
+    "axes[1].set_title('Binary Accuracy')\n",
+    "axes[1].set_xlabel('Epoch')\n",
+    "axes[1].legend()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "2a48f419",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test loss: 0.0131\n",
+      "Test binary accuracy: 0.9955\n",
+      "Exact match ratio: 0.9697\n",
+      "Precision micro: 0.9906\n",
+      "Recall micro: 0.9846\n",
+      "F1 micro: 0.9876\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Evaluación en test\n",
+    "test_loss, test_bin_acc = model.evaluate(x_test, y_test_ml, verbose=0)\n",
+    "print(f'Test loss: {test_loss:.4f}')\n",
+    "print(f'Test binary accuracy: {test_bin_acc:.4f}')\n",
+    "\n",
+    "# Predicciones multilabel con umbral\n",
+    "threshold = 0.5\n",
+    "y_prob = model.predict(x_test, verbose=0)\n",
+    "y_pred = (y_prob >= threshold).astype('float32')\n",
+    "\n",
+    "# Exact match ratio\n",
+    "exact_match = (y_pred == y_test_ml).all(axis=1).mean()\n",
+    "\n",
+    "# F1 micro (cálculo directo)\n",
+    "tp = np.logical_and(y_pred == 1, y_test_ml == 1).sum()\n",
+    "fp = np.logical_and(y_pred == 1, y_test_ml == 0).sum()\n",
+    "fn = np.logical_and(y_pred == 0, y_test_ml == 1).sum()\n",
+    "\n",
+    "precision_micro = tp / (tp + fp + 1e-8)\n",
+    "recall_micro = tp / (tp + fn + 1e-8)\n",
+    "f1_micro = 2 * precision_micro * recall_micro / (precision_micro + recall_micro + 1e-8)\n",
+    "\n",
+    "print(f'Exact match ratio: {exact_match:.4f}')\n",
+    "print(f'Precision micro: {precision_micro:.4f}')\n",
+    "print(f'Recall micro: {recall_micro:.4f}')\n",
+    "print(f'F1 micro: {f1_micro:.4f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "fc9b2de7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPoAAAERCAYAAABSGLrIAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAADepJREFUeJzt3QlsVEUcx/Ep0kIVUtKqtUbkEDVSg6IVlah4oESBCrEKphoQojHiQayowaPeEBMTFSNKBI9iDNYSguJ9QBpCETForBZi5YiGghWFloLSdsx/km160Hnbvt3t8f9+kg3tzrz3Zrf8dua9md1NstZaA6BX69PVDQAQfwQdUICgAwoQdEABgg4oQNABBQg6oABBBxQg6HH2xhtvmNdffz3ehwG8CHocff755+bOO+80Z555Zoe2e+utt0xSUpLZsWOH6U3kMT3xxBNd3QyVCHoHghe59e/f35x88slmwoQJ5uWXXzY1NTVttjl48KC54447zJNPPmkuv/zy0H+oV1991bVDq02bNpm7777bZGdnm+OOO86ceuqp5qabbjLbtm3r6qb1CEmsdQ8mAbvtttvMU089ZYYNG2aOHDliqqqqzNq1a80XX3zh/tOtXr3ajBo1qmmb++67z/0n/Pjjj92LQ0c0NDS4Y/Tr169p27PPPtscf/zx7pg9lTyWwsLCTvXqeXl5Zv369ebGG290z7M8/6+88oqpra01ZWVl7vmBhwQdfm+++aa88cdu2rSpTdlXX31lU1NT7ZAhQ2xdXV3cnsrs7Gw7btw4G28NDQ320KFDcdm3PIeFhYWd2nb9+vX233//bXHftm3bbL9+/Wx+fn6MWth7MXQP6corrzSPPfaY2blzp1m+fHnT/dJrte7JDx06ZO69917XMw8cONDk5uaaP/74o825a+tz9KFDh5ry8nKzbt26ptOH5qcDv/32m+vp0tPTzbHHHmsuuugis2bNmqjaL/uSIfG7777rhsUyivj0009dmbRt1qxZJjMz090v5cuWLWux/X///Wcef/xxc/7555u0tDQ3rL700kvNN998E9XxKyoqzK5duwLrjR071qSkpLS47/TTT3dt+uWXX6I6lmZ9u7oBvcGtt95q5s+f7y6+3X777e3Wmzlzpnn//fddfQmjBHfixImB+3/xxRfNPffcYwYMGGAeeeQRd5+ET+zZs8eFoK6uzr2IZGRkmLffftu9iHzwwQdm6tSpgfv/+uuvXbsk8PIiJC8ssl9pY+SF4IQTTjCffPKJmT17tjlw4ICZO3eu21Z+lpmFm2++2T12uV6xdOlSd/3i22+/Neeee6732GeddZYZN25cp05JZJAg7ZSwI0BXDyl6+tA9Ii0tzY4ePbrpdxmiNn96N2/e7H6fO3dui+1mzpzZZkgbOd727dsDh+6yP6lbWlradF9NTY0dNmyYHTp0qBuK+8i2ffr0seXl5S3unz17ts3KyrLV1dUt7p8+fbp7rJHTlPr6+jZD6r///ttmZmbaWbNmBQ7d5b7OnpIUFRW57ZcuXdqp7TVh6B4j0tse7ep7RGQ4fNddd7W4X3rqMORi35gxY8wll1zSoi1yxV+G/j///HPgPqRHHTlyZNPvkr+SkhIzefJk93N1dXXTTXrq/fv3m++//97VPeaYY5qG1I2NjWbfvn2mvr7e5OTkNNXxkf13pjeXIf+cOXPMxRdfbGbMmNHh7bVh6B4jcvX3xBNPbLdczuH79Onjrto3N2LEiFDHlf1eeOGFRx0SR8qDrki3btOff/5p/vnnH7NkyRJ3O5q9e/c2/SynCi+88IILn8wWtLffWJEr7nLKI9cE5PREXmzgR9Bj4Pfff3e9XNjQdpXU1NQWv0vPLG655ZZ2e8vIVKJcgJRrD1OmTDHz5s1zL3YSvAULFpjKysqYt1We52uvvda9EJWWlrr1DAhG0GOgqKjI/SvD2vYMGTLEBWj79u3uanHEr7/+GtUx2puLl/1u3bq1zf3Su0bKO0ouvMmsgMznjx8/3ltXetThw4eblStXtmijzJfH2uHDh93phKxP+PLLL1ucbsCPc/SQ5Ir1008/7Yap+fn57daLvAjICrfmFi1aFNVxZNpKerHWrrvuOnd1e8OGDS1W5cmQW66edyYM0iPfcMMN7jz9p59+alMuQ/vmdUXzzxjduHFji/bEYnpNXnSmTZvm9ltcXOzOzRE9evQOkOkl+Y8pF5tkWkdCLivjpNeUlXGyNLY9Ms8s4ZGpsr/++qtpei2yhDNo9Zxsv3jxYvPMM8+4UwQZIssc/sMPP2zee+89N5yV6TWZS5dzZhk5SFDlukBnLFy40M2Fy/m/TJvJC4ZcaJMLbNKbys9i0qRJrjeXaTw5b5bjvvbaa66+XLcIEu30WkFBgXuOpUeXYzdfsxA5zYBHV1/27wki012RW0pKij3ppJPs1VdfbV966SV74MCBNtu0nl4TBw8etHPmzLHp6el2wIABdsqUKXbr1q2u3sKFC73Ta1VVVXbixIl24MCBbaakKisrbV5enh00aJDt37+/HTNmjP3oo4+iemyyL2nT0ezZs8eVDR482CYnJ7vHfNVVV9klS5Y01WlsbLTPPfecWxkoq9RkilGOPWPGDHdfrKbXpE7zv0HrG/xY697FtmzZYkaPHu16KN/QHwiDc/QEkiWwrclQXobXl112WSKbAmU4R0+g559/3mzevNlcccUVpm/fvu6cX26yuGXw4MGJbAqUYeieQHLhTt6fLqvV5EKVvL1V1r3L+nUJPhAvBB1QgHN0QAGCDihA0AEFor4C1NHPPQOQGM2XH7eHHh1QgKADChB0QAGCDihA0AEFCDqgAEEHFCDogAIEHVCAoAMKEHRAAYIOKEDQAQUIOqAAQQcUIOiAAgQdUICgAwoQdEABgg4oQNABBQg6oABBBxQg6IACfIVngj3wwAOBdVJTU73lo0aN8pbn5eWZsBYvXuwt37Bhg7e8qKgodBsQO/TogAIEHVCAoAMKEHRAAYIOKEDQAQUIOqBAko3mW9SlYlJS/FvTC6xYsSLuc9zdQWVlpbd8/Pjx3vJdu3bFuEV62SgiTI8OKEDQAQUIOqAAQQcUIOiAAgQdUICgAwrwfvQeOE9eUVHhLf/ss8+85cOHDw88xuTJk73lp512mrc8Pz/fW75gwYLANiB26NEBBQg6oABBBxQg6IACBB1QgKADChB0QAHm0VvJycnxPmFTp04N9YSXl5cH1snNzfWWV1dXe8tra2u95SkpKYFtKCsr85afc8453vKMjIzAYyBx6NEBBQg6oABBBxQg6IACBB1QgKADChB0QAGCDijAgplWsrKyQn2RRdCCmAkTJgT+UXbv3m3iqaCgILDOyJEjQx1jzZo1obZHbNGjAwoQdEABgg4oQNABBQg6oABBBxQg6IACzKO38uGHH3qfsBEjRnjLa2pqvOX79u0zXW369OmBdZKTkxPSFiQGPTqgAEEHFCDogAIEHVCAoAMKEHRAAYIOKMA8egft3LnTdHfz5s3zlp9xxhmhj7Fx48ZQ5UgsenRAAYIOKEDQAQUIOqAAQQcUIOiAAgQdUCDJWmujqhjweeZInEmTJnnLi4uLveUpKSmBx9i7d2+o97SvW7cu8BiIjWgiTI8OKEDQAQUIOqAAQQcUIOiAAgQdUICgAwoQdEABPniiB8rJyQm9ICbIihUrvOUsiOlZ6NEBBQg6oABBBxQg6IACBB1QgKADChB0QAHm0buhVatWecuvueaaUPt/5513Aus8+uijoY6B7oUeHVCAoAMKEHRAAYIOKEDQAQUIOqAAQQcU4AscEiwrKyuwzg8//OAtz8jI8JZXV1d7y8eOHRvYhsrKysA66B74AgcADkN3QAGCDihA0AEFCDqgAEEHFCDogAK8Hz3BSkpKAusEzZMHWb58ubecOXJ96NEBBQg6oABBBxQg6IACBB1QgKADChB0QAGCDijAgpkYy83N9Zafd955oY+xdu1ab3lhYWHoY6B3oUcHFCDogAIEHVCAoAMKEHRAAYIOKEDQAQWYR++goA+FmD9/vrc8OTnZhLVlyxZveW1tbehjoHehRwcUIOiAAgQdUICgAwoQdEABgg4oQNABBZhH76CCggJv+QUXXGDCWrVqlbec95ujo+jRAQUIOqAAQQcUIOiAAgQdUICgAwoQdECBJGutjapiUlL8W9MDHD58OO7vNz/llFO85bt37w59DPQe0USYHh1QgKADChB0QAGCDihA0AEFCDqgAEEHFCDogAJ88EQ3lJ6e7i0/cuSI6Wr79+8P1cZoFhalpaWZMAYNGuQtv//++028NTQ0eMsfeuihwH3U1dWFbgc9OqAAQQcUIOiAAgQdUICgAwoQdEABgg4owDx6N/Tjjz+a7q64uDjUh2NkZmYGHmPatGmmt6uqqgqs8+yzz4Y+Dj06oABBBxQg6IACBB1QgKADChB0QAGCDijAFzh00MqVK73l119/fZi/Bzqgvr7eW97Y2Bj6+Vy9erW3/Lvvvgu1/9LS0sA6ZWVl3nK+wAGAw9AdUICgAwoQdEABgg4oQNABBQg6oADz6DH24IMPhv4887Cys7O7/H3ey5Yt85bv2LEj9DFKSkq85RUVFUYDa21gHXp0QAGCDihA0AEFCDqgAEEHFCDogAIEHVCAoAMKsGAG6OFYMAPAYegOKEDQAQUIOqAAQQcUIOiAAgQdUICgAwoQdEABgg4oQNABBQg6oABBBxQg6IACBB1QgKADChB0QAGCDihA0AEFCDqgAEEHFCDogAIEHVCAoAMKEHRAAYIOKEDQAQUIOqAAQQcUIOiAAgQdUICgAwoQdEABgg4oQNABBQg6oABBBxQg6IACBB1QgKADCvSNtqK1Nr4tARA39OiAAgQdUICgAwoQdEABgg4oQNABBQg6oABBBxQg6IDp/f4HtYsRSrB/9l0AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 300x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Vector de predicción de cada etiqueta: [0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 1. 1. 0.]\n",
+      "Etiquetas reales: ['digit_2', 'is_even', 'is_prime']\n",
+      "Etiquetas predichas: ['digit_2', 'is_even', 'is_prime']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Visualizamos una predicción de ejemplo\n",
+    "idx = 1\n",
+    "img = x_test[idx]\n",
+    "true_vec = y_test_ml[idx]\n",
+    "pred_vec = y_pred[idx]\n",
+    "\n",
+    "true_labels = [label_names[i] for i in np.where(true_vec == 1)[0]]\n",
+    "pred_labels = [label_names[i] for i in np.where(pred_vec == 1)[0]]\n",
+    "\n",
+    "plt.figure(figsize=(3, 3))\n",
+    "plt.imshow(img.squeeze(), cmap='gray')\n",
+    "plt.axis('off')\n",
+    "plt.title(f'Dígito real: {y_test[idx]}')\n",
+    "plt.show()\n",
+    "\n",
+    "print('Vector de predicción de cada etiqueta:', pred_vec)\n",
+    "print('Etiquetas reales:', true_labels)\n",
+    "print('Etiquetas predichas:', pred_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "654e2b73",
+   "metadata": {},
+   "source": [
+    "## Referencias\n",
+    "\n",
+    "1. Goodfellow, I., Bengio, Y., & Courville, A. (2016). *Deep Learning*. MIT Press. Capítulo 9: Convolutional Networks.\n",
+    "   - https://www.deeplearningbook.org/contents/convnets.html\n",
+    "\n",
+    "2. Chollet, F. (2021). *Deep Learning with Python* (2nd ed.). Manning. Capítulos sobre CNN en Keras y pipelines de entrenamiento.\n",
+    "   - https://sourestdeeds.github.io/pdf/Deep%20Learning%20with%20Python.pdf\n",
+    "\n",
+    "3. Zhang, M.-L., & Zhou, Z.-H. (2014). A Review on Multi-Label Learning Algorithms. *IEEE Transactions on Knowledge and Data Engineering*, 26(8), 1819–1837.\n",
+    "   - https://doi.org/10.1109/TKDE.2013.39\n",
+    "\n",
+    "4. Stanford CS231n (Fei-Fei Li, Justin Johnson, Serena Yeung). *Convolutional Neural Networks for Visual Recognition*. Material universitario, secciones sobre arquitecturas convolucionales y entrenamiento.\n",
+    "   - https://cs231n.github.io/convolutional-networks/"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Se ha creado un Notebook mostrando el funcionamiento básico de una red CNN multilabel que toma imágenes de ejemplo de MNIST y predice a qué etiquetas pertenece dicha imagen. Contiene referencias y una breve guía de pasos previos para asegurar el correcto funcionamiento del Notebook. 